### PR TITLE
Support parallel agent requests

### DIFF
--- a/examples/basic_agent.py
+++ b/examples/basic_agent.py
@@ -13,7 +13,7 @@ agent = Agent(
     name="Basic Agent",
     welcome="I am a simple agent here to help answer your weather questions.",
     instructions="You are a helpful assistant.",
-    model="gemini/gemini-2.0-flash", #"openai/gpt-4o-mini",
+    model="openai/gpt-4o-mini",
     tools=[WeatherTool()],
 )
 

--- a/examples/basic_agent.py
+++ b/examples/basic_agent.py
@@ -13,7 +13,7 @@ agent = Agent(
     name="Basic Agent",
     welcome="I am a simple agent here to help answer your weather questions.",
     instructions="You are a helpful assistant.",
-    model="openai/gpt-4o-mini",
+    model="gemini/gemini-2.0-flash", #"openai/gpt-4o-mini",
     tools=[WeatherTool()],
 )
 

--- a/examples/operator_agent.py
+++ b/examples/operator_agent.py
@@ -6,10 +6,11 @@ agent = Agent(
     name="Agentic Operator",
     welcome="Welcome the Operator Agent. What task would you like me to perform?",
     instructions="You have a browsing tool function which can browse websites and take actions.",
-    model="openai/gpt-4o-mini",
+    model="gemini/gemini-2.0-flash",
     tools=[
         BrowserUseTool(
             chrome_instance_path='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+            model="gemini/gemini-2.0-flash",
         ),
     ],
 )

--- a/examples/testing.py
+++ b/examples/testing.py
@@ -1,0 +1,17 @@
+from agentic.tools.unit_test_tool import UnitTestingTool
+
+from agentic.common import Agent, AgentRunner
+
+agent = Agent(
+    name="Agentic Testing",
+    welcome="This is a unit testing agent",
+    instructions="""
+    You have some functions to work with. Print verbose output about your steps and actions.
+    Print a message before and after each function call.
+""",
+    model="openai/gpt-4o", #"gemini/gemini-2.0-flash",
+    tools=[UnitTestingTool()]
+)
+
+if __name__ == "__main__":
+    AgentRunner(agent).repl_loop()

--- a/examples/testing.py
+++ b/examples/testing.py
@@ -9,7 +9,7 @@ agent = Agent(
     You have some functions to work with. Print verbose output about your steps and actions.
     Print a message before and after each function call.
 """,
-    model="openai/gpt-4o", #"gemini/gemini-2.0-flash",
+    model="openai/gpt-4o",
     tools=[UnitTestingTool()]
 )
 

--- a/src/agentic/actor_agents.py
+++ b/src/agentic/actor_agents.py
@@ -846,11 +846,11 @@ class RayFacadeAgent:
             DynamicFastAPIHandler.bind(self._agent, self),
             route_prefix=f"/{self.safe_name}",
         )
-        return deployment
+        return deployment, f"/{self.safe_name}"
 
 
-    def start_api_server(self, port: int = 8086):
-        self._create_fastapi_endpoint()
+    def start_api_server(self, port: int = 8086) -> str:
+        return self._create_fastapi_endpoint()[1]
 
     def _ensure_tool_secrets(self):
         from agentic.agentic_secrets import agentic_secrets

--- a/src/agentic/actor_agents.py
+++ b/src/agentic/actor_agents.py
@@ -6,6 +6,9 @@ from dataclasses import dataclass
 from functools import partial
 from collections import defaultdict
 from pathlib import Path
+from queue import Queue
+import threading
+
 import inspect
 import json
 import os
@@ -761,9 +764,6 @@ class DynamicFastAPIHandler:
             operations=["chat"],
         )
     
-from queue import Queue
-import threading
-
 class RayFacadeAgent:
     """The facade agent is the object directly instantiated in code. It holds a reference to the remote
     Ray agent object and proxies calls to it. The intention is that we should be able to build

--- a/src/agentic/cli.py
+++ b/src/agentic/cli.py
@@ -257,9 +257,11 @@ def serve(filename: str = typer.Argument(default="", show_default=False)):
     agent_instances = find_agent_instances(filename)
     for agent in agent_instances:
         runner = AgentRunner(agent)
-        runner.serve()
+        path = runner.serve()
 
     # Busy loop until ctrl-c or ctrl-d
+    os.system(f"open http://0.0.0.0:8086{path}/docs")
+
     while True:
         time.sleep(1)
 

--- a/src/agentic/events.py
+++ b/src/agentic/events.py
@@ -1,6 +1,7 @@
 # Shutup stupid pydantic warnings
 import warnings
 import typing
+import uuid
 
 warnings.filterwarnings("ignore", message="Valid config keys have changed in V2:*")
 
@@ -50,7 +51,8 @@ class Prompt(Event):
     # back to the top. Note that in Thespian, we don't have this address until the first receiveMessage
     # is called, so we set it then.
     debug: DebugLevel
-
+    request_id: str = uuid.uuid4().hex
+    
     def __init__(
         self,
         agent: str,
@@ -58,6 +60,7 @@ class Prompt(Event):
         debug: DebugLevel,
         depth: int = 0,
         ignore_result: bool = False,
+        request_id: str = None,
     ):
         data = {
             "agent": agent,
@@ -67,6 +70,8 @@ class Prompt(Event):
             "debug": debug,
             "ignore_result": ignore_result,
         }
+        if request_id:
+            data["request_id"] = request_id
         # Use Pydantic's model initialization directly
         BaseModel.__init__(self, **data)
 

--- a/src/agentic/runner.py
+++ b/src/agentic/runner.py
@@ -103,7 +103,8 @@ class RayAgentRunner:
         self.facade.set_debug_level(self.debug)
 
     def serve(self, port: int = 8086):
-        self.facade.start_api_server(port)
+        path = self.facade.start_api_server(port)
+        return path
 
     def repl_loop(self):
         hist = os.path.expanduser("~/.agentic_history")

--- a/src/agentic/tools/unit_test_tool.py
+++ b/src/agentic/tools/unit_test_tool.py
@@ -10,7 +10,7 @@ STATE_FILE = "test_state.txt"
 
 
 class UnitTestingTool(BaseAgenticTool):
-    def __init__(self, story_log: str):
+    def __init__(self, story_log: str="log.txt"):
         self.story_log = story_log
 
     def get_tools(self) -> list[Callable]:


### PR DESCRIPTION
This PR introduces an internal Queue when running agent requests. This allows the caller to stop listening for events for a while, while the agent continues. The next time you call `get_events(request_id)` then you will receive the events published in the meantime.

In the runner REPL we use this so you can "ctrl-c" a long task, and it will spawn a thread to keep reading events from the agent and echo them in gray to the terminal. Meanwhile you get a new prompt and can send another request:

 
![Screenshot 2025-02-19 at 11 27 15 AM](https://github.com/user-attachments/assets/772f355a-9c8d-4de8-9f9c-e6fb52c4beef)

this isn't really great in the REPL. But it should be better with a real web UI.

You can get the same thing with the REST API:

POST /process?request
<-- request_id

GET /get_events?request_id
<-- streams events