### PR TITLE
Add runs and run_logs models in a sqlite db

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "httpx>=0.28.1",
     "unicodedata2>=16.0.0",
     "sse-starlette>=2.2.1",
-    "gitpython>=3.1.44",
+    "sqlmodel>=0.0.22",
 ]
 
 [project.optional-dependencies]

--- a/src/agentic/actor_agents.py
+++ b/src/agentic/actor_agents.py
@@ -785,7 +785,7 @@ class RayFacadeAgent:
         model: str | None = None,
         template_path: str | Path = None,
         max_tokens: int = None,
-        enable_run_tracking: bool = True,
+        enable_run_logs: bool = True,
         memories: list[str] = [],
         handle_turn_start: Callable[[Prompt, RunContext], None] = None,
         debug: DebugLevel = DebugLevel(DebugLevel.OFF),
@@ -818,7 +818,7 @@ class RayFacadeAgent:
         self._init_base_actor(instructions or "")
 
         # Initialize adding runs to the agent
-        if enable_run_tracking:
+        if enable_run_logs:
             from .run_manager import init_run_tracking
             self.run_manager = init_run_tracking(self)
         else:

--- a/src/agentic/actor_agents.py
+++ b/src/agentic/actor_agents.py
@@ -82,11 +82,11 @@ from agentic.tools.registry import tool_registry
 
 __CTX_VARS_NAME__ = "run_context"
 
-# define a CallbackType Enum with values: "handle_turn_start", "handle_turn_end"
-CallbackType = Literal["handle_turn_start", "handle_turn_end"]
+# define a CallbackType Enum with values: "handle_turn_start", "handle_event", "handle_turn_end"
+CallbackType = Literal["handle_turn_start", "handle_event", "handle_turn_end"]
 
 # make a Callable type that expects a Prompt and RunContext
-CallbackFunc = Callable[[Prompt, RunContext], None]
+CallbackFunc = Callable[[Event, RunContext], None]
 
 @dataclass
 class AgentPauseContext:
@@ -402,6 +402,12 @@ class ActorBaseAgent:
         )
 
     def handlePromptOrResume(self, actor_message: Prompt | ResumeWithInput):
+        for event in self._handlePromptOrResume(actor_message):
+            if self._callbacks.get('handle_event'):
+                self._callbacks['handle_event'](event, self.run_context)
+            yield event
+
+    def _handlePromptOrResume(self, actor_message: Prompt | ResumeWithInput):
         if isinstance(actor_message, Prompt):
             # Middleware to modify the input prompt (or change agent context)
             self.run_context = (
@@ -633,8 +639,14 @@ class ActorBaseAgent:
         self.debug = debug
         print("agent set new debug level: ", debug)
 
-    def set_callback(self, key: CallbackType, callback: Callable):
-        self._callbacks[key] = callback
+    def get_callback(self, key: CallbackType) -> Optional[CallbackFunc]:
+        return self._callbacks.get(key)
+
+    def set_callback(self, key: CallbackType, callback: Optional[CallbackFunc]):
+        if callback is None:
+            self._callbacks.pop(key, None)
+        else:
+            self._callbacks[key] = callback
 
     def list_tools(self) -> list[str]:
         return self.tools
@@ -773,6 +785,7 @@ class RayFacadeAgent:
         model: str | None = None,
         template_path: str | Path = None,
         max_tokens: int = None,
+        enable_run_tracking: bool = True,
         memories: list[str] = [],
         handle_turn_start: Callable[[Prompt, RunContext], None] = None,
         debug: DebugLevel = DebugLevel(DebugLevel.OFF),
@@ -803,6 +816,13 @@ class RayFacadeAgent:
 
         # Initialize the base actor
         self._init_base_actor(instructions or "")
+
+        # Initialize adding runs to the agent
+        if enable_run_tracking:
+            from .run_manager import init_run_tracking
+            self.run_manager = init_run_tracking(self)
+        else:
+            self.run_manager = None
 
         # Ensure API key is set
         self.ensure_api_key_for_model(self.model)
@@ -994,3 +1014,13 @@ class RayFacadeAgent:
 
     def get_history(self):
         return ray.get(self._agent.get_history.remote())
+        
+    def set_run_tracking(self, enabled: bool, user_id: str = "default") -> None: #TODO: create a real user_id
+        """Enable or disable run tracking for this agent"""
+        if enabled and not self.run_manager:
+            from .run_manager import init_run_tracking
+            self.run_manager = init_run_tracking(self, user_id)
+        elif not enabled and self.run_manager:
+            from .run_manager import disable_run_tracking
+            disable_run_tracking(self)
+            self.run_manager = None

--- a/src/agentic/actor_agents.py
+++ b/src/agentic/actor_agents.py
@@ -79,6 +79,7 @@ from .events import (
     AgentDescriptor,
 )
 from agentic.tools.registry import tool_registry
+from agentic.db.db_manager import DatabaseManager
 
 __CTX_VARS_NAME__ = "run_context"
 
@@ -401,7 +402,7 @@ class ActorBaseAgent:
             self.depth,
         )
 
-    def handlePromptOrResume(self, actor_message: Prompt | ResumeWithInput):
+    def handlePromptOrResume(self, actor_message: Prompt | ResumeWithInput):            
         for event in self._handlePromptOrResume(actor_message):
             if self._callbacks.get('handle_event'):
                 self._callbacks['handle_event'](event, self.run_context)
@@ -786,6 +787,7 @@ class RayFacadeAgent:
         template_path: str | Path = None,
         max_tokens: int = None,
         enable_run_logs: bool = True,
+        db_path: Optional[str | Path] = None,
         memories: list[str] = [],
         handle_turn_start: Callable[[Prompt, RunContext], None] = None,
         debug: DebugLevel = DebugLevel(DebugLevel.OFF),
@@ -820,7 +822,10 @@ class RayFacadeAgent:
         # Initialize adding runs to the agent
         if enable_run_logs:
             from .run_manager import init_run_tracking
-            self.run_manager = init_run_tracking(self)
+            if db_path:
+                self.run_manager = init_run_tracking(self, db_path=db_path)
+            else:
+                self.run_manager = init_run_tracking(self)
         else:
             self.run_manager = None
 

--- a/src/agentic/db/db_manager.py
+++ b/src/agentic/db/db_manager.py
@@ -9,7 +9,7 @@ from agentic.events import FinishCompletion
 
 # Database setup and management
 class DatabaseManager:
-    def __init__(self, db_path: str = "~/.agentic/database.db"):
+    def __init__(self, db_path: str = "./runtime/agent_runs.db"):
         self.db_path = Path(db_path).expanduser()
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self.engine = create_engine(f"sqlite:///{self.db_path}", echo=False)
@@ -71,7 +71,7 @@ class DatabaseManager:
             if run:
                 run.updated_at = run_timestamp
                 # Update usage data if event contains it
-                if event_name == "completion_end" and "usage" in event_data:
+                if event_name == "completion_end":
                     usage = event_data["usage"]
 
                     # Make a copy so changes are detected

--- a/src/agentic/db/db_manager.py
+++ b/src/agentic/db/db_manager.py
@@ -1,0 +1,130 @@
+from datetime import datetime
+from typing import Dict, Optional
+from sqlmodel import Session, SQLModel, create_engine
+from pathlib import Path
+from copy import deepcopy
+
+from agentic.db.models import Run, RunLog
+from agentic.events import FinishCompletion
+
+# Database setup and management
+class DatabaseManager:
+    def __init__(self, db_path: str = "~/.agentic/runs.db"):
+        self.db_path = Path(db_path).expanduser()
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.engine = create_engine(f"sqlite:///{self.db_path}", echo=False)
+        self.create_db_and_tables()
+
+    def create_db_and_tables(self):
+        SQLModel.metadata.create_all(self.engine)
+
+    def get_session(self) -> Session:
+        return Session(self.engine)
+
+    def create_run(self, 
+                   agent_id: str,
+                   user_id: str,
+                   initial_prompt: str,
+                   description: Optional[str] = None,
+                   usage_data: Dict = None,
+                   run_metadata: Dict = None) -> Run:
+        run = Run(
+            agent_id=agent_id,
+            user_id=user_id,
+            initial_prompt=initial_prompt,
+            description=description,
+            usage_data=usage_data or {},
+            run_metadata=run_metadata or {}
+        )
+        
+        with self.get_session() as session:
+            session.add(run)
+            session.commit()
+            session.refresh(run)
+            return run
+
+    def log_event(self,
+                  run_id: int,
+                  agent_id: str,
+                  user_id: str,
+                  role: str,
+                  event_name: str,
+                  event_data: Dict) -> RunLog:
+        with self.get_session() as session:
+            run_timestamp = datetime.utcnow()
+            # Create the log entry
+            log = RunLog(
+                run_id=run_id,
+                agent_id=agent_id,
+                user_id=user_id,
+                role=role,
+                created_at=run_timestamp,
+                event_name=event_name,
+                event=event_data
+            )
+            session.add(log)
+            
+            # Update the parent run
+            run = session.get(Run, run_id)
+            if run:
+                run.updated_at = run_timestamp
+                # Update usage data if event contains it
+                if event_name == "completion_end" and "usage" in event_data:
+                    usage = event_data["usage"]
+
+                    # Make a copy so changes are detected
+                    usage_data = deepcopy(run.usage_data)
+                    for model in usage:
+                        if model not in usage_data:
+                            usage_data[model] = usage[model]
+                        else:
+                            usage_data[model][FinishCompletion.INPUT_TOKENS_KEY] += usage[model].get(FinishCompletion.INPUT_TOKENS_KEY, 0)
+                            usage_data[model][FinishCompletion.OUTPUT_TOKENS_KEY] += usage[model].get(FinishCompletion.OUTPUT_TOKENS_KEY, 0)
+                            usage_data[model][FinishCompletion.COST_KEY] += usage[model].get(FinishCompletion.COST_KEY, 0)
+                    
+                    run.usage_data = usage_data
+                session.add(run)
+            
+            session.commit()
+            session.refresh(log)
+            return log
+
+    def update_run(self,
+                   run_id: int,
+                   description: Optional[str] = None,
+                   usage_data: Optional[Dict] = None,
+                   run_metadata: Optional[Dict] = None) -> Optional[Run]:
+        with self.get_session() as session:
+            run = session.get(Run, run_id)
+            if run:
+                if description is not None:
+                    run.description = description
+                if usage_data is not None:
+                    run.usage_data.update(usage_data)
+                if run_metadata is not None:
+                    run.run_metadata.update(run_metadata)
+                run.updated_at = datetime.utcnow()
+                session.add(run)
+                session.commit()
+                session.refresh(run)
+                return run
+            return None
+
+    def get_run(self, run_id: int) -> Optional[Run]:
+        with self.get_session() as session:
+            return session.get(Run, run_id)
+
+    def get_run_logs(self, run_id: int) -> list[RunLog]:
+        with self.get_session() as session:
+            return session.query(RunLog).filter(RunLog.run_id == run_id).all()
+
+    def get_runs_by_user(self, user_id: str) -> list[Run]:
+        with self.get_session() as session:
+            return session.query(Run).filter(Run.user_id == user_id).all()
+
+    def get_runs_by_agent(self, agent_id: str) -> list[Run]:
+        with self.get_session() as session:
+            return session.query(Run).filter(Run.agent_id == agent_id).all()
+
+# Create a global database manager instance
+db_manager = DatabaseManager()

--- a/src/agentic/db/db_manager.py
+++ b/src/agentic/db/db_manager.py
@@ -21,14 +21,16 @@ class DatabaseManager:
     def get_session(self) -> Session:
         return Session(self.engine)
 
-    def create_run(self, 
+    def create_run(self,
                    agent_id: str,
                    user_id: str,
                    initial_prompt: str,
+                   run_id: Optional[str] = None,
                    description: Optional[str] = None,
                    usage_data: Dict = None,
                    run_metadata: Dict = None) -> Run:
         run = Run(
+            id=run_id,
             agent_id=agent_id,
             user_id=user_id,
             initial_prompt=initial_prompt,

--- a/src/agentic/db/models.py
+++ b/src/agentic/db/models.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+from typing import Dict, Optional
+from sqlmodel import Field, SQLModel, JSON, Column
+from uuid import uuid4
+
+# Define database models
+class Run(SQLModel, table=True):
+    __tablename__ = "runs"
+    
+    id: str = Field(primary_key=True, default_factory=lambda: str(uuid4()))
+    agent_id: str = Field(index=True)
+    user_id: str = Field(index=True)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    initial_prompt: str
+    description: Optional[str] = None
+    usage_data: Dict = Field(default={}, sa_column=Column(JSON))
+    run_metadata: Dict = Field(default={}, sa_column=Column(JSON))
+
+class RunLog(SQLModel, table=True):
+    __tablename__ = "run_logs"
+
+    id: str = Field(primary_key=True, default_factory=lambda: str(uuid4()))
+    run_id: int = Field(index=True, foreign_key="runs.id")
+    agent_id: str = Field(index=True)
+    user_id: str = Field(index=True)
+    role: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    event_name: str
+    event: Dict = Field(sa_column=Column(JSON))
+    version: int = Field(default=1)

--- a/src/agentic/run_manager.py
+++ b/src/agentic/run_manager.py
@@ -14,7 +14,7 @@ from agentic.utils.sqlite import make_json_serializable
 class RunManager:
     """
     Context manager that tracks agent runs and logs events to the database.
-    This is automatically initialized for all agents unless disabled with enable_run_tracking=False.
+    This is automatically initialized for all agents unless disabled with enable_run_logs=False.
     """
     
     def __init__(self, user_id: str = "default"):

--- a/src/agentic/run_manager.py
+++ b/src/agentic/run_manager.py
@@ -20,7 +20,7 @@ class RunManager:
     This is automatically initialized for all agents unless disabled with enable_run_logs=False.
     """
     
-    def __init__(self, initial_run_id: Optional[str] = None, user_id: str = "default", db_path: str = "~/.agentic/database.db"):
+    def __init__(self, initial_run_id: Optional[str] = None, user_id: str = "default", db_path: str = "./runtime/agent_runs.db"):
         self.user_id = user_id
         self.initial_run_id: Optional[str] = initial_run_id
         self.current_run_id: Optional[str] = None
@@ -104,7 +104,7 @@ class RunManager:
         if isinstance(event, TurnEnd):
             self.usage_data = {}
 
-def init_run_tracking(agent: Agent, user_id: str = "default", db_path: str = "~/.agentic/database.db") -> RunManager:
+def init_run_tracking(agent: Agent, user_id: str = "default", db_path: str = "./runtime/agent_runs.db") -> RunManager:
     """Helper function to set up run tracking for an agent"""
     run_id = str(uuid4())
     run_manager = RunManager(run_id, user_id, db_path)

--- a/src/agentic/run_manager.py
+++ b/src/agentic/run_manager.py
@@ -1,0 +1,108 @@
+from typing import Optional, Dict
+from litellm import Message
+from .events import (
+    Event,
+    PromptStarted,
+    TurnEnd,
+    FinishCompletion,
+    ToolCall,
+    ToolResult
+)
+from .common import Agent, RunContext
+from agentic.utils.sqlite import make_json_serializable
+
+class RunManager:
+    """
+    Context manager that tracks agent runs and logs events to the database.
+    This is automatically initialized for all agents unless disabled with enable_run_tracking=False.
+    """
+    
+    def __init__(self, user_id: str = "default"):
+        self.user_id = user_id
+        self.current_run_id: Optional[int] = None
+        self.usage_data: Dict = {}
+    
+    def handle_event(self, event: Event, run_context: RunContext) -> None:
+        """Generic event handler that processes all events and logs them appropriately"""
+        from agentic.db.db_manager import db_manager
+        
+        # Initialize a new run when we see a Prompt event
+        # TODO: Handle multiple prompts in a single run
+        if isinstance(event, PromptStarted):
+            run = db_manager.create_run(
+                agent_id=run_context.agent_name,
+                user_id=self.user_id,
+                initial_prompt=event.payload,
+            )
+            self.current_run_id = run.id
+            
+        # Skip if we haven't initialized a run yet
+        if not self.current_run_id:
+            return
+            
+        # Special handling for completion events to track usage
+        if isinstance(event, FinishCompletion) and event.metadata:
+            model = event.metadata.get(FinishCompletion.MODEL_KEY, "unknown")
+            if model not in self.usage_data:
+                self.usage_data[model] = {
+                    FinishCompletion.INPUT_TOKENS_KEY: 0,
+                    FinishCompletion.OUTPUT_TOKENS_KEY: 0,
+                    FinishCompletion.COST_KEY: 0
+                }
+            self.usage_data[model][FinishCompletion.INPUT_TOKENS_KEY] += event.metadata.get(FinishCompletion.INPUT_TOKENS_KEY, 0)
+            self.usage_data[model][FinishCompletion.OUTPUT_TOKENS_KEY] += event.metadata.get(FinishCompletion.OUTPUT_TOKENS_KEY, 0)
+            self.usage_data[model][FinishCompletion.COST_KEY] += event.metadata.get(FinishCompletion.COST_KEY, 0)
+            
+        # Determine role and event data based on event type
+        role = event.payload.role if isinstance(event.payload, Message) else "system"
+        event_name = event.type
+        payload = event.payload.content if isinstance(event.payload, Message) else event.payload
+        event_data = {"content": payload} if payload else {}
+        
+        if isinstance(event, ToolCall):
+            role = "tool"
+            event_data = {
+                "name": payload,
+                "arguments": make_json_serializable(event.args)
+            }
+            
+        elif isinstance(event, ToolResult):
+            role = "tool"
+            event_data = {
+                "name": payload,
+                "result": make_json_serializable(event.result)
+            }
+            
+        elif isinstance(event, FinishCompletion):
+            role = "usage"
+            event_data = {
+                "usage": self.usage_data
+            }
+
+        elif isinstance(event, TurnEnd):
+            event_data = {}
+            
+        # Log the event
+        db_manager.log_event(
+            run_id=self.current_run_id,
+            agent_id=run_context.agent_name,
+            user_id=self.user_id,
+            role=role,
+            event_name=event_name,
+            event_data=event_data
+        )
+        
+        # Reset usage tracking after a turn ends
+        if isinstance(event, TurnEnd):
+            self.usage_data = {}
+
+def init_run_tracking(agent: Agent, user_id: str = "default") -> RunManager:
+    """Helper function to set up run tracking for an agent"""
+    run_manager = RunManager(user_id)
+    agent._agent.set_callback.remote('handle_event', run_manager.handle_event)
+    return run_manager
+
+def disable_run_tracking(agent: Agent) -> None:
+    """Helper function to disable run tracking for an agent"""
+    if agent._agent.get_callback.remote('handle_event'):
+        agent._agent.set_callback.remote('handle_event', None)

--- a/src/agentic/tools/github_tool.py
+++ b/src/agentic/tools/github_tool.py
@@ -338,7 +338,6 @@ class GithubTool:
             if response.status_code in [200, 201, 204]:
                 return {'status': 'success', 'results': response.json()}
             else:
-                print(response.headers)
                 return {'status': 'error', 'message': f"API request failed: {response.text}"}
         
     def _get_repo_info(self, run_context: RunContext, repo_owner: Optional[str] = None, repo_name: Optional[str] = None) -> Tuple[str, str]:
@@ -475,7 +474,6 @@ class GithubTool:
             }
             for issue in results
         ]
-        print(slim_issues)
         return pd.DataFrame(slim_issues)
   
     async def get_github_issue_comments(self, run_context: RunContext, issue_number: int, repo_owner: Optional[str] = None, repo_name: Optional[str] = None) -> dict[str, Any]:

--- a/src/agentic/utils/sqlite.py
+++ b/src/agentic/utils/sqlite.py
@@ -1,0 +1,9 @@
+def make_json_serializable(obj):
+    """Recursively convert dictionary values to JSON-serializable types."""
+    if isinstance(obj, dict):
+        return {key: make_json_serializable(value) for key, value in obj.items()}
+    elif isinstance(obj, list):
+        return [make_json_serializable(item) for item in obj]
+    elif hasattr(obj, '__dict__'):  # For objects like RunContext
+        return str(obj)
+    return obj

--- a/tests/test_run_logging_core.py
+++ b/tests/test_run_logging_core.py
@@ -1,0 +1,226 @@
+import pytest
+from datetime import datetime
+from unittest.mock import Mock
+
+from agentic.db.db_manager import DatabaseManager
+from agentic.db.models import RunLog
+from agentic.run_manager import RunManager
+from agentic.common import RunContext
+from agentic.events import (
+    PromptStarted,
+    FinishCompletion,
+    ToolCall,
+    ToolResult,
+    TurnEnd
+)
+from litellm import Message
+
+@pytest.fixture
+def temp_db_path(tmp_path):
+    """Create a temporary database path for testing."""
+    return str(tmp_path / "test_runs.db")
+
+@pytest.fixture
+def db_manager(temp_db_path):
+    """Create a database manager instance with test configuration."""
+    return DatabaseManager(db_path=temp_db_path)
+
+@pytest.fixture
+def run_manager(temp_db_path):
+    """Create a RunManager instance with test configuration."""
+    return RunManager(user_id="test_user", db_path=temp_db_path)
+
+@pytest.fixture
+def run_context():
+    """Create a RunContext for testing."""
+    return RunContext(agent_name="test_agent", agent=Mock(), debug_level=None)
+
+def test_create_run(db_manager):
+    """Test creating a new run."""
+    run = db_manager.create_run(
+        agent_id="test_agent",
+        user_id="test_user",
+        initial_prompt="Test prompt",
+        description="Test description"
+    )
+    
+    assert run.id is not None
+    assert run.agent_id == "test_agent"
+    assert run.user_id == "test_user"
+    assert run.initial_prompt == "Test prompt"
+    assert run.description == "Test description"
+    assert isinstance(run.created_at, datetime)
+    assert isinstance(run.updated_at, datetime)
+    assert run.usage_data == {}
+    assert run.run_metadata == {}
+
+def test_log_event(db_manager):
+    """Test logging an event."""
+    # First create a run
+    run = db_manager.create_run(
+        agent_id="test_agent",
+        user_id="test_user",
+        initial_prompt="Test prompt"
+    )
+    
+    # Log an event
+    log = db_manager.log_event(
+        run_id=run.id,
+        agent_id="test_agent",
+        user_id="test_user",
+        role="assistant",
+        event_name="test_event",
+        event_data={"test": "data"}
+    )
+    
+    assert log.id is not None
+    assert log.run_id == run.id
+    assert log.agent_id == "test_agent"
+    assert log.user_id == "test_user"
+    assert log.role == "assistant"
+    assert log.event_name == "test_event"
+    assert log.event == {"test": "data"}
+    assert isinstance(log.created_at, datetime)
+    assert log.version == 1
+
+def test_update_run(db_manager):
+    """Test updating a run."""
+    run = db_manager.create_run(
+        agent_id="test_agent",
+        user_id="test_user",
+        initial_prompt="Test prompt"
+    )
+    
+    updated_run = db_manager.update_run(
+        run_id=run.id,
+        description="Updated description",
+        usage_data={"model": "test-model", "tokens": 100},
+        run_metadata={"key": "value"}
+    )
+    
+    assert updated_run is not None
+    assert updated_run.description == "Updated description"
+    assert updated_run.usage_data == {"model": "test-model", "tokens": 100}
+    assert updated_run.run_metadata == {"key": "value"}
+    assert updated_run.updated_at > run.updated_at
+
+def test_get_run(db_manager):
+    """Test retrieving a run."""
+    created_run = db_manager.create_run(
+        agent_id="test_agent",
+        user_id="test_user",
+        initial_prompt="Test prompt"
+    )
+    
+    retrieved_run = db_manager.get_run(created_run.id)
+    assert retrieved_run is not None
+    assert retrieved_run.id == created_run.id
+    assert retrieved_run.agent_id == created_run.agent_id
+
+def test_get_run_logs(db_manager):
+    """Test retrieving logs for a run."""
+    run = db_manager.create_run(
+        agent_id="test_agent",
+        user_id="test_user",
+        initial_prompt="Test prompt"
+    )
+    
+    # Create multiple logs
+    for i in range(3):
+        db_manager.log_event(
+            run_id=run.id,
+            agent_id="test_agent",
+            user_id="test_user",
+            role="assistant",
+            event_name=f"test_event_{i}",
+            event_data={"test": f"data_{i}"}
+        )
+    
+    logs = db_manager.get_run_logs(run.id)
+    assert len(logs) == 3
+    assert all(isinstance(log, RunLog) for log in logs)
+    assert all(log.run_id == run.id for log in logs)
+
+def test_get_runs_by_user(db_manager):
+    """Test retrieving runs for a specific user."""
+    # Create runs for different users
+    user1_runs = [
+        db_manager.create_run(
+            agent_id="test_agent",
+            user_id="user1",
+            initial_prompt=f"Test prompt {i}"
+        )
+        for i in range(2)
+    ]
+    
+    user2_run = db_manager.create_run(
+        agent_id="test_agent",
+        user_id="user2",
+        initial_prompt="Test prompt"
+    )
+    
+    retrieved_runs = db_manager.get_runs_by_user("user1")
+    assert len(retrieved_runs) == 2
+    assert all(run.user_id == "user1" for run in retrieved_runs)
+
+def test_get_runs_by_agent(db_manager):
+    """Test retrieving runs for a specific agent."""
+    # Create runs for different agents
+    agent1_runs = [
+        db_manager.create_run(
+            agent_id="agent1",
+            user_id="test_user",
+            initial_prompt=f"Test prompt {i}"
+        )
+        for i in range(2)
+    ]
+    
+    agent2_run = db_manager.create_run(
+        agent_id="agent2",
+        user_id="test_user",
+        initial_prompt="Test prompt"
+    )
+    
+    retrieved_runs = db_manager.get_runs_by_agent("agent1")
+    assert len(retrieved_runs) == 2
+    assert all(run.agent_id == "agent1" for run in retrieved_runs)
+
+def test_run_manager_handle_events(db_manager, run_manager, run_context):
+    """Test RunManager event handling."""
+    # Test handling PromptStarted event
+    prompt_event = PromptStarted(agent="test_agent", message="Test prompt")
+    run_manager.handle_event(prompt_event, run_context)
+    assert run_manager.current_run_id is not None
+    
+    # Test handling FinishCompletion event
+    completion_event = FinishCompletion.create(
+        agent="test_agent",
+        llm_message=Message(content="Test response", role="assistant"),
+        model="test-model",
+        cost=0.001,
+        input_tokens=10,
+        output_tokens=20,
+        elapsed_time=1.0
+    )
+    run_manager.handle_event(completion_event, run_context)
+    
+    # Test handling tool events
+    tool_call = ToolCall(agent="test_agent", name="test_tool", args={"arg": "value"})
+    run_manager.handle_event(tool_call, run_context)
+    
+    tool_result = ToolResult(agent="test_agent", name="test_tool", result="success")
+    run_manager.handle_event(tool_result, run_context)
+    
+    # Test handling TurnEnd event
+    turn_end = TurnEnd(agent="test_agent", messages=[], run_context=run_context)
+    run_manager.handle_event(turn_end, run_context)
+    
+    # Verify logs were created
+    logs = db_manager.get_run_logs(run_manager.current_run_id)
+    assert len(logs) > 0
+    
+    # Verify usage data was tracked
+    run = db_manager.get_run(run_manager.current_run_id)
+    assert "test-model" in run.usage_data
+    assert run.usage_data["test-model"]["input_tokens"] == 10
+    assert run.usage_data["test-model"]["output_tokens"] == 20

--- a/tests/test_run_logging_integration.py
+++ b/tests/test_run_logging_integration.py
@@ -1,0 +1,176 @@
+import pytest
+from pathlib import Path
+from datetime import datetime, timedelta
+
+from agentic.common import Agent, AgentRunner
+from agentic.db.db_manager import DatabaseManager
+from agentic.run_manager import init_run_tracking, disable_run_tracking
+
+class SimpleCalculator:
+    def get_tools(self):
+        return [
+            self.add,
+            self.subtract
+        ]
+
+    def add(self, a: float, b: float) -> str:
+        """Add two numbers"""
+        return str(float(a) + float(b))
+        
+    def subtract(self, a: float, b: float) -> str:
+        """Subtract b from a"""
+        return str(float(a) - float(b))
+
+@pytest.fixture
+def temp_db_path(tmp_path):
+    """Create a temporary database path for testing."""
+    return str(tmp_path / "test_runs.db")
+
+@pytest.fixture
+def db_manager(temp_db_path):
+    """Create a database manager instance with test configuration."""
+    return DatabaseManager(db_path=temp_db_path)
+
+@pytest.fixture
+def test_agent(temp_db_path):
+    """Create a simple test agent with basic math capabilities."""
+    agent = Agent(
+        name="Calculator",
+        instructions="""You are a helpful calculator assistant. Use the provided tools to perform calculations.
+        Always explain your work before using a tool.""",
+        tools=[SimpleCalculator()],
+        model="gpt-4o-mini",
+        db_path=temp_db_path
+    )
+    return agent
+
+def test_run_logging_enabled(test_agent, db_manager):
+    """Test that run logging works correctly when enabled."""
+    runner = AgentRunner(test_agent)
+    
+    # Run a simple calculation
+    runner.turn("What is 5 plus 3?")
+    
+    # Verify the run was created
+    runs = db_manager.get_runs_by_user("default")
+    assert len(runs) == 1
+    run = runs[0]
+    
+    # Verify run metadata
+    assert run.agent_id == "Calculator"
+    assert run.user_id == "default"
+    assert run.initial_prompt == "What is 5 plus 3?"
+    assert isinstance(run.created_at, datetime)
+    assert isinstance(run.updated_at, datetime)
+    
+    # Get all logs for this run
+    logs = db_manager.get_run_logs(run.id)
+    
+    # Verify essential events were logged
+    event_names = [log.event_name for log in logs]
+    assert 'prompt_started' in event_names
+    assert 'completion_end' in event_names
+    assert 'tool_call' in event_names
+    assert 'tool_result' in event_names
+    assert 'turn_end' in event_names
+    
+    # Verify tool usage was logged correctly
+    tool_calls = [log for log in logs if log.event_name == 'tool_call']
+    assert len(tool_calls) > 0
+    assert tool_calls[0].event['name'] == 'add'
+    
+    # Verify token usage was tracked
+    assert any('input_tokens' in log.event.get('usage', {}).get(test_agent.model, {})
+                for log in logs if log.event_name == 'completion_end')
+    
+    # Run another calculation to verify multiple runs are tracked
+    runner.turn("What is 10 minus 4?")
+    
+    runs = db_manager.get_runs_by_user("default")
+    assert len(runs) == 2
+
+def test_run_logging_disabled(db_manager):
+    """Test that no logging occurs when run logging is disabled."""
+    # Disable run tracking
+    no_logging_agent = Agent(
+        name="Calculator",
+        instructions="""You are a helpful calculator assistant. Use the provided tools to perform calculations.
+        Always explain your work before using a tool.""",
+        tools=[SimpleCalculator()],
+        model="gpt-4o-mini",
+        enable_run_logs=False
+    )
+    runner = AgentRunner(no_logging_agent)
+    
+    # Run a calculation
+    runner.turn("What is 7 plus 2?")
+    
+    # Verify no runs were created
+    runs = db_manager.get_runs_by_agent("Calculator")
+    assert len(runs) == 0
+    
+    # Run another calculation
+    runner.turn("What is 15 minus 5?")
+    
+    # Verify still no runs
+    runs = db_manager.get_runs_by_agent("Calculator")
+    assert len(runs) == 0
+
+def test_run_logging_toggle(test_agent, db_manager, temp_db_path):
+    """Test that logging can be toggled on and off."""    
+    runner = AgentRunner(test_agent)
+    
+    # Start with logging disabled
+    disable_run_tracking(test_agent)
+    runner.turn("What is 3 plus 4?")
+    
+    runs = db_manager.get_runs_by_agent("Calculator")
+    assert len(runs) == 0
+    
+    # Enable logging
+    init_run_tracking(test_agent, db_path=temp_db_path)
+    runner.turn("What is 8 minus 5?")
+    
+    runs = db_manager.get_runs_by_agent("Calculator")
+    assert len(runs) == 1
+    
+    # Disable logging again
+    disable_run_tracking(test_agent)
+    runner.turn("What is 6 plus 7?")
+    
+    runs = db_manager.get_runs_by_agent("Calculator")
+    assert len(runs) == 1  # Count should not have increased
+
+def test_run_usage_accumulation(test_agent, db_manager):
+    """Test that token usage is accumulated correctly across multiple completions in a run."""    
+    runner = AgentRunner(test_agent)
+    
+    # Run a multi-step interaction
+    runner.turn("First add 5 and 3, then subtract 2 from the result.")
+    
+    # Get the run and its logs
+    runs = db_manager.get_runs_by_user("default")
+    assert len(runs) == 1
+    run = runs[0]
+    
+    # Verify usage data accumulation
+    assert test_agent.model in run.usage_data
+    model_usage = run.usage_data[test_agent.model]
+    assert model_usage['input_tokens'] > 0
+    assert model_usage['output_tokens'] > 0
+    
+    # Verify the sum of individual completion usages matches the accumulated total
+    logs = db_manager.get_run_logs(run.id)
+    completion_logs = [log for log in logs if log.event_name == 'completion_end']
+    
+    total_input_tokens = sum(
+        log.event.get('usage', {}).get(test_agent.model, {}).get('input_tokens', 0)
+        for log in completion_logs
+    )
+    total_output_tokens = sum(
+        log.event.get('usage', {}).get(test_agent.model, {}).get('output_tokens', 0)
+        for log in completion_logs
+    )
+    
+    assert model_usage['input_tokens'] == total_input_tokens
+    assert model_usage['output_tokens'] == total_output_tokens

--- a/tests/test_run_logging_integration.py
+++ b/tests/test_run_logging_integration.py
@@ -55,6 +55,7 @@ def test_run_logging_enabled(test_agent, db_manager):
     runs = db_manager.get_runs_by_user("default")
     assert len(runs) == 1
     run = runs[0]
+    initial_run_logs_count = len(db_manager.get_run_logs(run.id))
     
     # Verify run metadata
     assert run.agent_id == "Calculator"
@@ -87,7 +88,10 @@ def test_run_logging_enabled(test_agent, db_manager):
     runner.turn("What is 10 minus 4?")
     
     runs = db_manager.get_runs_by_user("default")
-    assert len(runs) == 2
+    new_run_logs_count = len(db_manager.get_run_logs(run.id))
+    # Make sure the length of runs is one but that the number of run logs increased
+    assert len(runs) == 1
+    assert new_run_logs_count > initial_run_logs_count
 
 def test_run_logging_disabled(db_manager):
     """Test that no logging occurs when run logging is disabled."""


### PR DESCRIPTION
Resolves #7 
## Changes
- Added Run and RunLog db models that live inside a sqlite db
- Added a flag `enable_run_logs` that is default true that logs runs and their logs to the db
- Added `handle_event` to the `ActorBaseAgent` to be run before each event is yielded in `handlePromptOrResume`
- Added a `db_manager` which has basic CRUD operations for runs and run_logs
- Added a `run_manager` that has the `handle_event` callback declared inside it and adds the handler based on if `enable_run_logs` is enabled

## To Do:
- [x] Add tests
- [x] Make multiple prompts correspond to the same run
- [ ] [Future] Add concepts of agent_id and user_id