### PR TITLE
added /_discovery REST endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ runtime/
 
 venv/
 env/
+.DS_Store

--- a/docs/REST_API.md
+++ b/docs/REST_API.md
@@ -15,6 +15,12 @@ you can start the API server with the CLI:
 that you can use to interact with it
 programmatically. The AgentRunner runs a _FastAPI_ service that exposes an interface to your agent.
 
+There is a discovery endpoint which lists all agent paths:
+
+    http://0.0.0.0:8086/_discovery
+
+This will list `/basic_agent` as an available path.
+
 Your agent will expose endpoints at:
 
     http://0.0.0.0:8086/<name of agent>


### PR DESCRIPTION
With the `_discovery` endpoint a client can discover all the running agents and their subpaths. From this it can build chooser menu, or can auto-discover the current single running agent.

<img width="464" alt="Screenshot 2025-02-19 at 3 51 13 PM" src="https://github.com/user-attachments/assets/fb0f7aa3-f857-46c0-9a58-6c0b550d9bb5" />



<img width="639" alt="Screenshot 2025-02-19 at 3 44 42 PM" src="https://github.com/user-attachments/assets/f6e2c6d2-e6d0-4583-9655-416adc93ba01" />
