### PR TITLE
added support for logging from tools using either yield or by calling run_context methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,20 @@ ANTHROPIC_API_KEY=your_anthropic_api_key_here
 
 You only need to set the API keys for the models you plan to use. For example, if you're only using OpenAI models, you only need to set `OPENAI_API_KEY`.
 
+### Tests and docs
+
+Run tests:
+
+    pytest
+
+Preview docs locally:
+
+    mkdocs serve
+
+Deploy the docs:
+
+    mkdocs gh-deploy
+
 ## Why does this exist?
 
 Yup, there's a lot of agent frameworks. But many of these are "gen 1" frameworks - designed
@@ -121,10 +135,9 @@ Some reasons why Agentic is different:
 calling directly into the LLM API (the OpenAI _completion_ API via _Litellm_).
 - Logging is **built-in** and usable out of the box. Trace agent runs, tool calls, and LLM completions
 with ability to control the right level of detail.
-- Very simple and well designed abstractions with just a few nouns: Agent, Tool, Run, Pipeline. You can easily
-build complex agent teams and flows, but don't have to assemble the _computational graph_ by hand.
-- Agents are asynchronous and generate typed events, not just text. Consuming an event stream
-allows lots of rich interactions and different media types.
+- Well designed abstractions with just a few nouns: Agent, Tool, Thread, Run. Stop assembling
+the _computational graph_ out of toothpicks.
+- Rich event system goes beyond text so agents can work with data and media.
 - Event streams can have _multiple channels_, so your agent can "run in the background" and
 still notify you of what is happening.
 - Human-in-the-loop is built into the framework, not hacked in. An agent can wait indefinitely,

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -1,0 +1,13 @@
+# Data Model
+
+`Agent` - a named unit of execution which supports one or more operations and maintains a persistent state.
+
+`Thread` - when you interact with an agent you do so in the context of a "thread", which maintains a
+history of interactions (events in and events out) with the agent. A Thread has no definite "end" state.
+
+`Run` - requesting the agent to perform an operation constitutes a "run". So Threads are composed of
+a sequence of Runs. A Run might be in-process, interrupted, continued, or completed.
+
+`Event` - as the agent runs it publishes events, keyed to the Run and the Thread.
+
+?? "request_id"

--- a/docs/RestApiTool.md
+++ b/docs/RestApiTool.md
@@ -1,0 +1,38 @@
+# REST API Tools
+
+`RESTAPIToolV2`
+
+The base tool offering REST API calling functions.
+
+`AuthorizedRESTAPITool`
+
+This tool is an easy way to access REST APIs that require authentication. Construct the
+tool passing these args:
+
+    token_type: str, token_var: str, token_name: str
+
+Where token_type is "bearer", "basic", "parameter", "header". The "token_var" is the
+name of the stored secret that the tool will use for the actual credential.
+
+You need to set the actual credential as a secret in your environment or using `agentic set-secret`.
+
+Examples:
+
+    AuthorizedeRESTAPITool("bearer", "HEROKU_API_KEY")  - Bearer token. Set "HEROKU_API_KEY" in secrets
+
+    AuthorizedeRESTAPITool("basic", "MY_AUTH")  - Basic auth.  Set "MY_AUTH" secret to "<username>:<password>"
+
+    AuthorizedeRESTAPITool("parameter", "TAVILY_API_KEY, "api_key") - passes TAVILY_API_KEY secret as api_key param
+
+    AuthorizedeRESTAPITool("header", "TAVILY_API_KEY, "x-api-key") - Passes a "x-api-key" header
+
+Once the auth is setup properly, the tool simply exposes these functions to your agent:
+
+    get_resource
+    post_resource
+    put_resource
+    patch_resource
+    delete_resource
+
+which it can use to make REST API calls.
+

--- a/docs/ToolLibrary.md
+++ b/docs/ToolLibrary.md
@@ -1,0 +1,6 @@
+# Available Tools
+
+Here are some of the tools that come built-in with Agentic:
+
+### `AuthorizedRESTAPITool`
+

--- a/examples/oss_deep_research.py
+++ b/examples/oss_deep_research.py
@@ -15,7 +15,10 @@
 # For each report section we call 'process_section' which does content gathering and writing
 # for each section.
 #
-# You can run at the command line with:
+### RUNNING ###
+#
+# You need a TAVILY_API_KEY, and the API key for whatever model you are using, like OPENAI_API_KEY.
+# Set these in your environment or use `agentic set-secret` to set them.
 #
 #   python examples/oss_deep_research.py
 #
@@ -43,7 +46,6 @@ from agentic.agentic_secrets import agentic_secrets
 from agentic.models import GPT_4O_MINI, CLAUDE, GPT_4O
 from agentic.events import Event, ChatOutput
 from agentic.tools.tavily_search_tool import TavilySearchTool
-
 
 # These can take any Litellm model path [see https://supercog-ai.github.io/agentic/Models/]
 # Or use aliases 'GPT_4O' or 'CLAUDE'

--- a/src/agentic/events.py
+++ b/src/agentic/events.py
@@ -145,7 +145,7 @@ class ToolResult(Event):
 
 
 class ToolOutput(Event):
-    result: Any
+    result: Optional[Any] = None # make Pydantic not complain when we super.init
 
     def __init__(self, agent: str, name: str, result: Any, depth: int = 0):
         super().__init__(agent=agent, type="tool_result", payload=name, depth=depth)

--- a/src/agentic/swarm/types.py
+++ b/src/agentic/swarm/types.py
@@ -80,6 +80,7 @@ class RunContext:
         self.debug_level = debug_level
         self.run_id = run_id
         self.api_endpoint = api_endpoint
+        self._log_queue: list = []
 
     def __getitem__(self, key):
         return self._context.get(key, None)
@@ -101,6 +102,24 @@ class RunContext:
         return settings.get(
             self.agent_name + "/" + key, settings.get(key, self.get(key, default))
         )
+
+    def log(self, *args):
+        """ Makes and returns a ToolOutput event. You can ignore the return value and let
+            the system automatically publish log messages queued during the tool call. """
+        from agentic.events import ToolOutput
+        import inspect
+
+        caller_frame = inspect.currentframe().f_back
+        caller_name = inspect.getframeinfo(caller_frame).function
+        event = ToolOutput(self.agent_name, caller_name, result=" ".join(map(str, args)))
+        self._log_queue.append(event)
+        return event
+    
+    def get_logs(self):
+        return self._log_queue
+    
+    def reset_logs(self):
+        self._log_queue = []
 
     def set_setting(self, key, value):
         settings.set(self.agent_name + "/" + key, value)

--- a/src/agentic/tools/__init__.py
+++ b/src/agentic/tools/__init__.py
@@ -17,5 +17,6 @@ from .base import BaseAgenticTool
 # ]
 
 from .registry import tool_registry, Dependency, Tool
+from ..events import ToolOutput
 
 __all__ = ["tool_registry", "Dependency", "Tool"]

--- a/src/agentic/tools/unit_test_tool.py
+++ b/src/agentic/tools/unit_test_tool.py
@@ -3,6 +3,7 @@ import os
 from typing import Callable
 
 from .base import BaseAgenticTool
+from agentic.common import RunContext
 
 # A dummy tool created just for unit testing
 
@@ -20,6 +21,9 @@ class UnitTestingTool(BaseAgenticTool):
             self.read_state_file,
             self.test_using_async_call,
             self.read_story_log,
+            self.sync_function_with_logging,
+            self.sync_function_direct_logging,
+            self.async_function_with_logging,
         ]
 
     def sleep_for_time(self, seconds: int):
@@ -55,3 +59,18 @@ class UnitTestingTool(BaseAgenticTool):
         """Reads and returns the story log content."""
         await asyncio.sleep(0.2)
         return self.story_log
+
+    def sync_function_with_logging(self, run_context: RunContext):
+        """ A function that logs to the run context. """
+        run_context.log("Something interesting happened: ", "thing1", "thing2")
+        return "can you see the logs?"
+
+    def sync_function_direct_logging(self, run_context: RunContext):
+        """ A function that logs directly via yield. """
+        yield run_context.log("Something interesting happened: ", "thing1", "thing2")
+        return "I yielded a log message"
+    
+    async def async_function_with_logging(self, run_context: RunContext):
+        """ An async function that logs to the run context. """
+        yield run_context.log("ASYNC interesting happened: ", "thing1", "thing2")
+        yield "can you see the logs?"

--- a/tests/test_tool_logging.py
+++ b/tests/test_tool_logging.py
@@ -1,0 +1,69 @@
+import pytest
+from agentic.common import Agent, AgentRunner
+from agentic.tools.unit_test_tool import UnitTestingTool
+from agentic.models import CLAUDE, GPT_4O_MINI
+from agentic.events import ToolOutput, TurnEnd
+
+model = GPT_4O_MINI
+
+# Test the various ways we logging from tools.
+
+
+@pytest.fixture
+def parent():
+    story_log = "This is the log from the parent. The sun sets over the horizon."
+    child_story_log = "I am just a child in this crazy, agentic world."
+
+    return Agent(
+        name="TheParent",
+        model=model,
+        tools=[
+            UnitTestingTool(story_log),
+            Agent(
+                name="TheChild",
+                model=model,
+                tools=[UnitTestingTool(child_story_log)],
+                enable_run_logs=False,
+            )
+        ]
+    )
+
+def test_sync_logging(parent):
+    tool_outputs = []
+    turn_end = None
+    for event in parent.next_turn("call sync_function_with_logging"):
+        if isinstance(event, ToolOutput):
+            tool_outputs.append(event)
+        elif isinstance(event, TurnEnd):
+            turn_end = event
+
+    print("Turn end: ", turn_end)
+    assert len(tool_outputs) > 0
+
+def test_async_logging(parent):
+    tool_outputs = []
+    turn_end = None
+    for event in parent.next_turn("call async_function_with_logging"):
+        if isinstance(event, ToolOutput):
+            tool_outputs.append(event)
+        elif isinstance(event, TurnEnd):
+            turn_end = event
+
+    print("Turn end: ", turn_end)
+    assert len(tool_outputs) > 0
+    assert tool_outputs[0].payload == "async_function_with_logging"
+    assert "ASYNC" in tool_outputs[0].result
+
+def test_direct_logging(parent):
+    tool_outputs = []
+    turn_end = None
+    for event in parent.next_turn("call sync_function_direct_logging"):
+        if isinstance(event, ToolOutput):
+            tool_outputs.append(event)
+        elif isinstance(event, TurnEnd):
+            turn_end = event
+
+    print("Turn end: ", turn_end)
+    assert len(tool_outputs) > 0
+    assert tool_outputs[0].payload == "sync_function_direct_logging"
+    assert "Something interesting happened" in tool_outputs[0].result


### PR DESCRIPTION
Logging inside tool function is very important. This PR adds support for a couple different approaches. The first is to use yield, but then you tool function becomes a generator:

```
def tool_func():
  yield ToolOutput("something happened")
  yield ToolOutput("something else")
  ..
   yield "final result"
```

This may feel weird, so you can also do this instead:

```
def tool_func(run_context):
   run_context.log("log1")
   run_context.log("log2")
   ..   
   return "final result"
```

This works by having run_context queue the log events, and then they will get auto-published (before the tool result) when you function completes.

✅ added docs and tests 