### PR TITLE
Added autoescape to Jinja template rendering to prevent render errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ At this stage it's probably easiest to run this repo from source. We use `uv` fo
 ```
 git clone git@github.com:supercog-ai/agentic.git
 cd agentic
+uv venv --python 3.12
 uv pip install -e ".[all,dev]"
+source .venv/bin/activate
 ```
 
 these commands will install the `agentic` package locally so that you can use the `agentic` cli command

--- a/src/agentic/cli.py
+++ b/src/agentic/cli.py
@@ -226,7 +226,12 @@ import time
 def serve(filename: str = typer.Argument(default="", show_default=False)):
     """Runs the FastAPI server for an agent"""
     from agentic.common import AgentRunner
-
+    if not os.getcwd().endswith("runtime"):
+        try:
+            os.chdir("runtime")
+        except:
+            pass
+        
     def find_agent_instances(file_path):
         # Load the module from file path
         spec = importlib.util.spec_from_file_location("dynamic_module", file_path)

--- a/src/agentic/tools/meeting_tool.py
+++ b/src/agentic/tools/meeting_tool.py
@@ -15,12 +15,12 @@ from agentic.utils.rag_helper import init_weaviate, create_collection, init_embe
 import logging  
 
 # Configure logging  
-logging.basicConfig(  
-    level=logging.INFO,  # Set the minimum log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)  
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",  # Set the log format  
-    datefmt="%Y-%m-%d %H:%M:%S",  # Set the date format  
-)  
-logger = logging.getLogger(__name__)
+# logging.basicConfig(  
+#     level=logging.INFO,  # Set the minimum log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)  
+#     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",  # Set the log format  
+#     datefmt="%Y-%m-%d %H:%M:%S",  # Set the date format  
+# )  
+# logger = logging.getLogger(__name__)
 
 Base = declarative_base()
 


### PR DESCRIPTION
I also added a new `. serve` command to the repl, but struggled with serialization errors if we try to start the FastAPI server after the Ray agent is already running. I'm still not sure if it's working reliably