### PR TITLE
Added oauth support for tools

### DIFF
--- a/src/agentic/events.py
+++ b/src/agentic/events.py
@@ -447,21 +447,24 @@ class OauthFlowRequest(Event):
         scope: str = "",
         depth: int = 0
     ):
-        super().__init__(
-            agent=agent,
-            type="oauth_flow_request",
-            payload={
+        # First initialize the base Event fields
+        data = {
+            "agent": agent,
+            "type": "oauth_flow_request",
+            "payload": {
                 "message": message,
                 "authorize_url": authorize_url,
                 "auth_code_name": auth_code_name,
                 "scope": scope
             },
-            depth=depth
-        )
-        self.message = message
-        self.authorize_url = authorize_url
-        self.auth_code_name = auth_code_name
-        self.scope = scope
+            "depth": depth,
+            # Add required OauthFlowRequest fields
+            "authorize_url": authorize_url,
+            "auth_code_name": auth_code_name,
+            "message": message,
+            "scope": scope
+        }
+        super().__init__(**data)
 
     def __str__(self):
         return f"[OAUTH] {self.message}\nAuthorize URL: {self.authorize_url}"

--- a/src/agentic/events.py
+++ b/src/agentic/events.py
@@ -430,3 +430,38 @@ class SSEDecoder:
             pass  # Field is ignored.
 
         return None
+
+class OauthFlowRequest(Event):
+    """Event requesting OAuth authorization flow"""
+    authorize_url: str
+    auth_code_name: str
+    message: str
+    scope: str = ""
+    
+    def __init__(
+        self,
+        agent: str,
+        message: str,
+        authorize_url: str, 
+        auth_code_name: str,
+        scope: str = "",
+        depth: int = 0
+    ):
+        super().__init__(
+            agent=agent,
+            type="oauth_flow_request",
+            payload={
+                "message": message,
+                "authorize_url": authorize_url,
+                "auth_code_name": auth_code_name,
+                "scope": scope
+            },
+            depth=depth
+        )
+        self.message = message
+        self.authorize_url = authorize_url
+        self.auth_code_name = auth_code_name
+        self.scope = scope
+
+    def __str__(self):
+        return f"[OAUTH] {self.message}\nAuthorize URL: {self.authorize_url}"

--- a/src/agentic/events.py
+++ b/src/agentic/events.py
@@ -290,6 +290,7 @@ class AddChild(Event):
 PAUSE_FOR_INPUT_SENTINEL = "__PAUSE4INPUT__"
 PAUSE_FOR_CHILD_SENTINEL = "__PAUSE__CHILD"
 FINISH_AGENT_SENTINEL = "__FINISH__"
+OAUTH_FLOW_SENTINEL = "__OAUTH_FLOW__"
 
 
 class WaitForInput(Event):
@@ -315,6 +316,46 @@ class ResumeWithInput(Event):
     def request_keys(self):
         return self.payload
 
+class OAuthFlow(Event):
+    """Event emitted when OAuth flow needs to be initiated"""
+    def __init__(self, agent: str, auth_url: str, tool_name: str, depth: int = 0):
+        super().__init__(
+            agent=agent, 
+            type="oauth_flow",
+            payload={"auth_url": auth_url, "tool_name": tool_name},
+            depth=depth
+        )
+
+    def __str__(self):
+        return self._indent(
+            f"OAuth authorization required for {self.payload['tool_name']}.\n"
+            f"Please visit: {self.payload['auth_url']}\n"
+            "After authorizing, the flow will continue automatically."
+        )
+
+class OAuthFlowResult(Result):
+    """Result indicating OAuth flow needs to be initiated"""
+    request_keys: dict = {}
+
+    def __init__(self, request_keys: dict):
+        """
+        Args:
+            request_keys: Dictionary containing 'auth_url' and 'tool_name' keys
+        """
+        super().__init__(value=OAUTH_FLOW_SENTINEL)
+        self.request_keys = request_keys
+
+    @property
+    def auth_url(self) -> str:
+        return self.request_keys["auth_url"]
+        
+    @property
+    def tool_name(self) -> str:
+        return self.request_keys["tool_name"]
+
+    @staticmethod 
+    def matches_sentinel(value) -> bool:
+        return value == OAUTH_FLOW_SENTINEL
 
 class PauseForInputResult(Result):
     request_keys: dict = {}
@@ -430,41 +471,3 @@ class SSEDecoder:
             pass  # Field is ignored.
 
         return None
-
-class OauthFlowRequest(Event):
-    """Event requesting OAuth authorization flow"""
-    authorize_url: str
-    auth_code_name: str
-    message: str
-    scope: str = ""
-    
-    def __init__(
-        self,
-        agent: str,
-        message: str,
-        authorize_url: str, 
-        auth_code_name: str,
-        scope: str = "",
-        depth: int = 0
-    ):
-        # First initialize the base Event fields
-        data = {
-            "agent": agent,
-            "type": "oauth_flow_request",
-            "payload": {
-                "message": message,
-                "authorize_url": authorize_url,
-                "auth_code_name": auth_code_name,
-                "scope": scope
-            },
-            "depth": depth,
-            # Add required OauthFlowRequest fields
-            "authorize_url": authorize_url,
-            "auth_code_name": auth_code_name,
-            "message": message,
-            "scope": scope
-        }
-        super().__init__(**data)
-
-    def __str__(self):
-        return f"[OAUTH] {self.message}\nAuthorize URL: {self.authorize_url}"

--- a/src/agentic/runner.py
+++ b/src/agentic/runner.py
@@ -154,12 +154,11 @@ class RayAgentRunner:
                         continue_result = replies
                         continue_result["request_id"] = request_id
                     elif isinstance(event, OAuthFlow):
-                        # Print OAuth authorization instructions with formatting
-                        print("==== OAuth Authorization Required ====")
-                        print(f"Tool: {event.payload['tool_name']}")
-                        print(f"Please visit this URL to authorize:")
-                        print(event.payload['auth_url'])
-                        print("Authorization will continue automatically after completion")
+                        console.print("==== OAuth Authorization Required ====", style="bold yellow")
+                        console.print(f"Tool: [cyan]{event.payload['tool_name']}[/cyan]")
+                        console.print("Please visit this URL to authorize:", style="bold white")
+                        console.print(event.payload['auth_url'], style="blue underline")
+                        console.print("Authorization will continue automatically after completion", style="dim")
                     elif isinstance(event, FinishCompletion):
                         saved_completions.append(event)
                     if self._should_print(event):

--- a/src/agentic/runner.py
+++ b/src/agentic/runner.py
@@ -25,6 +25,7 @@ from agentic.events import (
     TurnEnd,
     WaitForInput,
     ToolError,
+    OAuthFlow
 )
 
 # Global console for Rich
@@ -151,7 +152,13 @@ class RayAgentRunner:
                                 print(f"\n{value}\n")
                                 replies[key] = input(":> ")
                         continue_result = replies
-                        continue_result["request_id"] = request_id
+                    elif isinstance(event, OAuthFlow):
+                        # Print OAuth authorization instructions with formatting
+                        print("\n" + Colors.BLUE + "==== OAuth Authorization Required ====")
+                        print(f"Tool: {event.payload['tool_name']}")
+                        print(f"Please visit this URL to authorize:")
+                        print(Colors.GREEN + event.payload['auth_url'])
+                        print(Colors.BLUE + "Authorization will continue automatically after completion")
                     elif isinstance(event, FinishCompletion):
                         saved_completions.append(event)
                     if self._should_print(event):

--- a/src/agentic/runner.py
+++ b/src/agentic/runner.py
@@ -152,13 +152,14 @@ class RayAgentRunner:
                                 print(f"\n{value}\n")
                                 replies[key] = input(":> ")
                         continue_result = replies
+                        continue_result["request_id"] = request_id
                     elif isinstance(event, OAuthFlow):
                         # Print OAuth authorization instructions with formatting
-                        print("\n" + Colors.BLUE + "==== OAuth Authorization Required ====")
+                        print("==== OAuth Authorization Required ====")
                         print(f"Tool: {event.payload['tool_name']}")
                         print(f"Please visit this URL to authorize:")
-                        print(Colors.GREEN + event.payload['auth_url'])
-                        print(Colors.BLUE + "Authorization will continue automatically after completion")
+                        print(event.payload['auth_url'])
+                        print("Authorization will continue automatically after completion")
                     elif isinstance(event, FinishCompletion):
                         saved_completions.append(event)
                     if self._should_print(event):

--- a/src/agentic/swarm/types.py
+++ b/src/agentic/swarm/types.py
@@ -185,7 +185,8 @@ class RunContext:
             # Fallback to default if not set
             host = "localhost" 
             port = 8086
-            base_url = f"http://{host}:{port}/{self.agent_name}"
+            safe_agent_name = "".join(c if c.isalnum() else "_" for c in self.agent_name).lower()
+            base_url = f"http://{host}:{port}/{safe_agent_name}"
         else:
             base_url = self.api_endpoint
             

--- a/src/agentic/swarm/types.py
+++ b/src/agentic/swarm/types.py
@@ -163,7 +163,8 @@ class RunContext:
             # Fallback to default if not set
             host = "localhost"
             port = 8086
-            base_url = f"http://{host}:{port}/{self.agent_name}" 
+            safe_agent_name = "".join(c if c.isalnum() else "_" for c in self.agent_name).lower()
+            base_url = f"http://{host}:{port}/{safe_agent_name}" 
         else:
             base_url = self.api_endpoint
 

--- a/src/agentic/swarm/types.py
+++ b/src/agentic/swarm/types.py
@@ -178,10 +178,7 @@ class RunContext:
         return webhook_url
 
     def get_oauth_callback_url(self, tool_name: str) -> str:
-        """Get the OAuth callback URL for a tool"""
-        if not self.run_id:
-            raise ValueError("No active run_id. OAuth requires an active agent run.")
-        
+        """Get the static OAuth callback URL for a tool"""
         if not self.api_endpoint:
             # Fallback to default if not set
             host = "localhost" 
@@ -191,7 +188,22 @@ class RunContext:
         else:
             base_url = self.api_endpoint
             
-        return f"{base_url}/oauth/{self.run_id}/{tool_name}"
+        return f"{base_url}/oauth/callback/{tool_name}"
+
+    def get_oauth_auth_code(self, tool_name: str) -> Optional[str]:
+        """Get OAuth authorization code for a tool if available"""
+        auth_key = f"{tool_name}_auth_code"
+        return self.get(auth_key)
+
+    def set_oauth_token(self, tool_name: str, token: str):
+        """Store OAuth token for a tool securely"""
+        token_key = f"{tool_name}_oauth_token"
+        self.set_secret(token_key, token)
+        
+    def get_oauth_token(self, tool_name: str) -> Optional[str]:
+        """Get OAuth token for a tool if available"""
+        token_key = f"{tool_name}_oauth_token"
+        return self.get_secret(token_key)
 
 
 class SwarmAgent(BaseModel):

--- a/src/agentic/swarm/types.py
+++ b/src/agentic/swarm/types.py
@@ -193,7 +193,12 @@ class RunContext:
     def get_oauth_auth_code(self, tool_name: str) -> Optional[str]:
         """Get OAuth authorization code for a tool if available"""
         auth_key = f"{tool_name}_auth_code"
-        return self.get(auth_key)
+        return self.get_secret(auth_key)
+
+    def set_oauth_auth_code(self, tool_name: str, auth_code: str):
+        """Store OAuth authorization code for a tool using secure storage"""
+        auth_key = f"{tool_name}_auth_code"
+        self.set_secret(auth_key, auth_code)
 
     def set_oauth_token(self, tool_name: str, token: str):
         """Store OAuth token for a tool securely"""

--- a/src/agentic/swarm/types.py
+++ b/src/agentic/swarm/types.py
@@ -176,6 +176,21 @@ class RunContext:
         
         return webhook_url
 
+    def get_oauth_callback_url(self, tool_name: str) -> str:
+        """Get the OAuth callback URL for a tool"""
+        if not self.run_id:
+            raise ValueError("No active run_id. OAuth requires an active agent run.")
+        
+        if not self.api_endpoint:
+            # Fallback to default if not set
+            host = "localhost" 
+            port = 8086
+            base_url = f"http://{host}:{port}/{self.agent_name}"
+        else:
+            base_url = self.api_endpoint
+            
+        return f"{base_url}/oauth/{self.run_id}/{tool_name}"
+
 
 class SwarmAgent(BaseModel):
     name: str = "Agent"

--- a/src/agentic/tools/oauth_tool.py
+++ b/src/agentic/tools/oauth_tool.py
@@ -1,0 +1,117 @@
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+from urllib.parse import urlencode
+
+import httpx
+from agentic.common import RunContext
+from agentic.events import OAuthFlowResult
+
+@dataclass
+class OAuthConfig:
+    """Configuration for OAuth flow"""
+    authorize_url: str
+    token_url: str
+    client_id_key: str
+    client_secret_key: str
+    scopes: str
+    tool_name: str
+
+class OAuthTool:
+    """Base class for tools that need OAuth authentication"""
+    
+    def __init__(self, oauth_config: OAuthConfig):
+        self.oauth_config = oauth_config
+
+    async def authenticate(self, run_context: RunContext) -> str | OAuthFlowResult:
+        """Start or continue OAuth authentication flow"""
+        # Check for existing token
+        token = run_context.get_oauth_token(self.oauth_config.tool_name)
+        if token:
+            return f"Already authenticated with {self.oauth_config.tool_name}"
+
+        # Check for auth code
+        auth_code = run_context.get_oauth_auth_code(self.oauth_config.tool_name)
+        if auth_code:
+            token = await self._exchange_code_for_token(auth_code, run_context)
+            if token:
+                return f"Successfully authenticated with {self.oauth_config.tool_name}"
+            return f"Failed to exchange authorization code for token with {self.oauth_config.tool_name}"
+
+        # Start OAuth flow
+        return await self._start_oauth_flow(run_context)
+
+    async def _start_oauth_flow(self, run_context: RunContext) -> OAuthFlowResult:
+        """Initialize OAuth authorization flow"""
+        client_id = run_context.get_secret(self.oauth_config.client_id_key)
+        if not client_id:
+            raise ValueError(f"{self.oauth_config.client_id_key} not found in secrets")
+
+        callback_url = run_context.get_oauth_callback_url(self.oauth_config.tool_name)
+        
+        params = {
+            "client_id": client_id,
+            "redirect_uri": callback_url,
+            "scope": self.oauth_config.scopes,  
+            "state": run_context.run_id
+        }
+        
+        # Add any additional params from child class
+        extra_params = self._get_extra_auth_params(run_context)
+        if extra_params:
+            params.update(extra_params)
+        
+        auth_url = f"{self.oauth_config.authorize_url}?{urlencode(params)}"
+
+        return OAuthFlowResult({
+            "auth_url": auth_url,
+            "tool_name": self.oauth_config.tool_name
+        })
+
+    async def _exchange_code_for_token(self, auth_code: str, run_context: RunContext) -> Optional[str]:
+        """Exchange OAuth code for access token"""
+        client_id = run_context.get_secret(self.oauth_config.client_id_key)
+        client_secret = run_context.get_secret(self.oauth_config.client_secret_key)
+
+        if not client_id or not client_secret:
+            return None
+
+        data = {
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "code": auth_code
+        }
+
+        # Add any additional data from child class
+        extra_data = self._get_extra_token_data(run_context)
+        if extra_data:
+            data.update(extra_data)
+
+        async with httpx.AsyncClient() as client:
+            headers = {"Accept": "application/json"}
+            response = await client.post(
+                self.oauth_config.token_url,
+                json=data,
+                headers=headers
+            )
+
+            if response.status_code == 200:
+                token_data = response.json()
+                access_token = token_data.get("access_token")
+                if access_token:
+                    run_context.set_oauth_token(self.oauth_config.tool_name, access_token)
+                    # Allow child class to handle additional token data
+                    await self._handle_token_response(token_data, run_context)
+                    return access_token
+        return None
+
+    def _get_extra_auth_params(self, run_context: RunContext) -> Dict[str, Any]:
+        """Override to add additional authorization parameters"""
+        return {}
+
+    def _get_extra_token_data(self, run_context: RunContext) -> Dict[str, Any]:
+        """Override to add additional token exchange data"""
+        return {}
+
+    async def _handle_token_response(self, token_data: Dict[str, Any], run_context: RunContext):
+        """Override to handle additional token response data"""
+        pass

--- a/src/agentic/tools/oauth_tool.py
+++ b/src/agentic/tools/oauth_tool.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 from urllib.parse import urlencode
+import os
 
 import httpx
 from agentic.common import RunContext
@@ -42,9 +43,9 @@ class OAuthTool:
 
     async def _start_oauth_flow(self, run_context: RunContext) -> OAuthFlowResult:
         """Initialize OAuth authorization flow"""
-        client_id = run_context.get_secret(self.oauth_config.client_id_key)
+        client_id = os.getenv(self.oauth_config.client_id_key)
         if not client_id:
-            raise ValueError(f"{self.oauth_config.client_id_key} not found in secrets")
+            raise ValueError(f"{self.oauth_config.client_id_key} not found in environment variables")
 
         callback_url = run_context.get_oauth_callback_url(self.oauth_config.tool_name)
         
@@ -69,8 +70,8 @@ class OAuthTool:
 
     async def _exchange_code_for_token(self, auth_code: str, run_context: RunContext) -> Optional[str]:
         """Exchange OAuth code for access token"""
-        client_id = run_context.get_secret(self.oauth_config.client_id_key)
-        client_secret = run_context.get_secret(self.oauth_config.client_secret_key)
+        client_id = os.getenv(self.oauth_config.client_id_key)
+        client_secret = os.getenv(self.oauth_config.client_secret_key)
 
         if not client_id or not client_secret:
             return None

--- a/src/agentic/tools/oauth_tool.py
+++ b/src/agentic/tools/oauth_tool.py
@@ -96,7 +96,7 @@ class OAuthTool:
             )
 
             if response.status_code == 200:
-                token_data = response.json()
+                token_data = await response.json()
                 access_token = token_data.get("access_token")
                 if access_token:
                     run_context.set_oauth_token(self.oauth_config.tool_name, access_token)

--- a/tests/test_oauth_tool.py
+++ b/tests/test_oauth_tool.py
@@ -1,13 +1,14 @@
-from unittest.mock import Mock, patch, AsyncMock
 import pytest
+from unittest.mock import Mock, AsyncMock, patch
 from agentic.tools.oauth_tool import OAuthTool, OAuthConfig
 from agentic.events import OAuthFlowResult
+from agentic.common import RunContext
 
 @pytest.fixture
 def oauth_config():
     return OAuthConfig(
-        authorize_url="https://example.com/authorize",
-        token_url="https://example.com/token",
+        authorize_url="https://test.com/auth",
+        token_url="https://test.com/token",
         client_id_key="TEST_CLIENT_ID",
         client_secret_key="TEST_CLIENT_SECRET",
         scopes="test_scope",
@@ -16,12 +17,8 @@ def oauth_config():
 
 @pytest.fixture
 def mock_run_context():
-    context = Mock()
-    context.run_id = "test_run_id"
-    context.get_oauth_callback_url = Mock(return_value="https://callback.com")
-    context.get_oauth_token = Mock(return_value=None)
-    context.get_oauth_auth_code = Mock(return_value=None)
-    context.set_oauth_token = Mock()
+    context = Mock(spec=RunContext)
+    context.run_id = "test_run_123"
     return context
 
 @pytest.fixture
@@ -29,94 +26,93 @@ def oauth_tool(oauth_config):
     return OAuthTool(oauth_config)
 
 @pytest.mark.asyncio
-async def test_start_oauth_flow_success(oauth_tool, mock_run_context):
-    """Test successful OAuth flow initialization"""
-    with patch('os.getenv', return_value='test_client_id'):
-        result = await oauth_tool._start_oauth_flow(mock_run_context)
+async def test_authenticate_with_existing_token(oauth_tool, mock_run_context):
+    # Setup mock to return existing token
+    mock_run_context.get_oauth_token.return_value = "existing_token"
+    
+    result = await oauth_tool.authenticate(mock_run_context)
+    
+    assert result == "Already authenticated with test_tool"
+    mock_run_context.get_oauth_token.assert_called_once_with("test_tool")
+
+@pytest.mark.asyncio
+async def test_authenticate_with_auth_code(oauth_tool, mock_run_context):
+    # Setup mocks
+    mock_run_context.get_oauth_token.return_value = None
+    mock_run_context.get_oauth_auth_code.return_value = "test_auth_code"
+    
+    # Mock the token exchange
+    with patch.object(oauth_tool, '_exchange_code_for_token', new_callable=AsyncMock) as mock_exchange:
+        mock_exchange.return_value = "new_token"
         
-        assert isinstance(result, OAuthFlowResult)
-        assert 'auth_url' in result.data
-        assert 'tool_name' in result.data
-        assert result.data['tool_name'] == 'test_tool'
-        assert 'client_id=test_client_id' in result.data['auth_url']
-        assert 'scope=test_scope' in result.data['auth_url']
-
-@pytest.mark.asyncio
-async def test_start_oauth_flow_missing_client_id(oauth_tool, mock_run_context):
-    """Test OAuth flow initialization with missing client ID"""
-    with patch('os.getenv', return_value=None):
-        with pytest.raises(ValueError) as exc_info:
-            await oauth_tool._start_oauth_flow(mock_run_context)
-        assert "TEST_CLIENT_ID not found in environment variables" in str(exc_info.value)
-
-@pytest.mark.asyncio
-async def test_exchange_code_for_token_success(oauth_tool, mock_run_context):
-    """Test successful token exchange"""
-    mock_response = Mock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {'access_token': 'test_token'}
-    
-    mock_client = AsyncMock()
-    mock_client.post.return_value = mock_response
-    
-    with patch('os.getenv', side_effect=['test_client_id', 'test_client_secret']), \
-         patch('httpx.AsyncClient', return_value=mock_client):
-        token = await oauth_tool._exchange_code_for_token('test_code', mock_run_context)
+        result = await oauth_tool.authenticate(mock_run_context)
         
-        assert token == 'test_token'
-        mock_run_context.set_oauth_token.assert_called_once_with('test_tool', 'test_token')
+        assert result == "Successfully authenticated with test_tool"
+        mock_exchange.assert_called_once_with("test_auth_code", mock_run_context)
 
 @pytest.mark.asyncio
-async def test_exchange_code_for_token_failure(oauth_tool, mock_run_context):
-    """Test token exchange failure"""
-    mock_response = Mock()
-    mock_response.status_code = 400
+async def test_authenticate_start_oauth_flow(oauth_tool, mock_run_context, monkeypatch):
+    # Setup mocks to trigger OAuth flow start
+    mock_run_context.get_oauth_token.return_value = None
+    mock_run_context.get_oauth_auth_code.return_value = None
+    mock_run_context.get_oauth_callback_url.return_value = "https://callback.url"
     
-    mock_client = AsyncMock()
-    mock_client.post.return_value = mock_response
+    # Use monkeypatch instead of directly setting env var
+    monkeypatch.setenv("TEST_CLIENT_ID", "test_client_id")
     
-    with patch('os.getenv', side_effect=['test_client_id', 'test_client_secret']), \
-         patch('httpx.AsyncClient', return_value=mock_client):
-        token = await oauth_tool._exchange_code_for_token('test_code', mock_run_context)
+    result = await oauth_tool.authenticate(mock_run_context)
+    
+    assert isinstance(result, OAuthFlowResult)
+    assert "auth_url" in result.request_keys
+    assert result.request_keys["tool_name"] == "test_tool"
+
+@pytest.mark.asyncio
+async def test_exchange_code_for_token(oauth_tool, mock_run_context, monkeypatch):
+    # Use monkeypatch for environment variables
+    monkeypatch.setenv("TEST_CLIENT_ID", "test_client_id")
+    monkeypatch.setenv("TEST_CLIENT_SECRET", "test_client_secret")
+    
+    with patch('httpx.AsyncClient.post', new_callable=AsyncMock) as mock_post:
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {"access_token": "new_token"}
+        
+        token = await oauth_tool._exchange_code_for_token("test_auth_code", mock_run_context)
+        
+        assert token == "new_token"
+        mock_run_context.set_oauth_token.assert_called_once_with("test_tool", "new_token")
+
+@pytest.mark.asyncio
+async def test_exchange_code_for_token_failure(oauth_tool, mock_run_context, monkeypatch):
+    # Use monkeypatch for environment variables
+    monkeypatch.setenv("TEST_CLIENT_ID", "test_client_id")
+    monkeypatch.setenv("TEST_CLIENT_SECRET", "test_client_secret")
+    
+    with patch('httpx.AsyncClient.post', new_callable=AsyncMock) as mock_post:
+        # Mock failed token response
+        mock_post.return_value.status_code = 400
+        
+        token = await oauth_tool._exchange_code_for_token("test_auth_code", mock_run_context)
         
         assert token is None
         mock_run_context.set_oauth_token.assert_not_called()
 
 @pytest.mark.asyncio
-async def test_authenticate_existing_token(oauth_tool, mock_run_context):
-    """Test authentication with existing token"""
-    mock_run_context.get_oauth_token.return_value = 'existing_token'
+async def test_start_oauth_flow_missing_client_id(oauth_tool, mock_run_context):
+    mock_run_context.get_oauth_callback_url.return_value = "https://callback.url"
     
-    result = await oauth_tool.authenticate(mock_run_context)
+    with pytest.raises(ValueError) as exc_info:
+        await oauth_tool._start_oauth_flow(mock_run_context)
     
-    assert "Already authenticated" in result
-    mock_run_context.get_oauth_token.assert_called_once_with('test_tool')
+    assert "TEST_CLIENT_ID not found in environment variables" in str(exc_info.value)
+
+def test_extra_params_methods(oauth_tool, mock_run_context):
+    # Test default implementations of extra params methods
+    assert oauth_tool._get_extra_auth_params(mock_run_context) == {}
+    assert oauth_tool._get_extra_token_data(mock_run_context) == {}
 
 @pytest.mark.asyncio
-async def test_authenticate_with_auth_code(oauth_tool, mock_run_context):
-    """Test authentication with authorization code"""
-    mock_run_context.get_oauth_auth_code.return_value = 'test_auth_code'
-    
-    mock_response = Mock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {'access_token': 'new_token'}
-    
-    mock_client = AsyncMock()
-    mock_client.post.return_value = mock_response
-    
-    with patch('os.getenv', side_effect=['test_client_id', 'test_client_secret']), \
-         patch('httpx.AsyncClient', return_value=mock_client):
-        result = await oauth_tool.authenticate(mock_run_context)
-        
-        assert "Successfully authenticated" in result
-        mock_run_context.set_oauth_token.assert_called_once_with('test_tool', 'new_token')
-
-@pytest.mark.asyncio
-async def test_authenticate_start_new_flow(oauth_tool, mock_run_context):
-    """Test starting new authentication flow"""
-    with patch('os.getenv', return_value='test_client_id'):
-        result = await oauth_tool.authenticate(mock_run_context)
-        
-        assert isinstance(result, OAuthFlowResult)
-        assert 'auth_url' in result.data
-        assert result.data['tool_name'] == 'test_tool'
+async def test_handle_token_response(oauth_tool, mock_run_context):
+    # Test default implementation of handle token response
+    token_data = {"access_token": "test_token"}
+    await oauth_tool._handle_token_response(token_data, mock_run_context)
+    # Should complete without errors

--- a/tests/test_oauth_tool.py
+++ b/tests/test_oauth_tool.py
@@ -1,0 +1,122 @@
+from unittest.mock import Mock, patch, AsyncMock
+import pytest
+from agentic.tools.oauth_tool import OAuthTool, OAuthConfig
+from agentic.events import OAuthFlowResult
+
+@pytest.fixture
+def oauth_config():
+    return OAuthConfig(
+        authorize_url="https://example.com/authorize",
+        token_url="https://example.com/token",
+        client_id_key="TEST_CLIENT_ID",
+        client_secret_key="TEST_CLIENT_SECRET",
+        scopes="test_scope",
+        tool_name="test_tool"
+    )
+
+@pytest.fixture
+def mock_run_context():
+    context = Mock()
+    context.run_id = "test_run_id"
+    context.get_oauth_callback_url = Mock(return_value="https://callback.com")
+    context.get_oauth_token = Mock(return_value=None)
+    context.get_oauth_auth_code = Mock(return_value=None)
+    context.set_oauth_token = Mock()
+    return context
+
+@pytest.fixture
+def oauth_tool(oauth_config):
+    return OAuthTool(oauth_config)
+
+@pytest.mark.asyncio
+async def test_start_oauth_flow_success(oauth_tool, mock_run_context):
+    """Test successful OAuth flow initialization"""
+    with patch('os.getenv', return_value='test_client_id'):
+        result = await oauth_tool._start_oauth_flow(mock_run_context)
+        
+        assert isinstance(result, OAuthFlowResult)
+        assert 'auth_url' in result.data
+        assert 'tool_name' in result.data
+        assert result.data['tool_name'] == 'test_tool'
+        assert 'client_id=test_client_id' in result.data['auth_url']
+        assert 'scope=test_scope' in result.data['auth_url']
+
+@pytest.mark.asyncio
+async def test_start_oauth_flow_missing_client_id(oauth_tool, mock_run_context):
+    """Test OAuth flow initialization with missing client ID"""
+    with patch('os.getenv', return_value=None):
+        with pytest.raises(ValueError) as exc_info:
+            await oauth_tool._start_oauth_flow(mock_run_context)
+        assert "TEST_CLIENT_ID not found in environment variables" in str(exc_info.value)
+
+@pytest.mark.asyncio
+async def test_exchange_code_for_token_success(oauth_tool, mock_run_context):
+    """Test successful token exchange"""
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {'access_token': 'test_token'}
+    
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    
+    with patch('os.getenv', side_effect=['test_client_id', 'test_client_secret']), \
+         patch('httpx.AsyncClient', return_value=mock_client):
+        token = await oauth_tool._exchange_code_for_token('test_code', mock_run_context)
+        
+        assert token == 'test_token'
+        mock_run_context.set_oauth_token.assert_called_once_with('test_tool', 'test_token')
+
+@pytest.mark.asyncio
+async def test_exchange_code_for_token_failure(oauth_tool, mock_run_context):
+    """Test token exchange failure"""
+    mock_response = Mock()
+    mock_response.status_code = 400
+    
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    
+    with patch('os.getenv', side_effect=['test_client_id', 'test_client_secret']), \
+         patch('httpx.AsyncClient', return_value=mock_client):
+        token = await oauth_tool._exchange_code_for_token('test_code', mock_run_context)
+        
+        assert token is None
+        mock_run_context.set_oauth_token.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_authenticate_existing_token(oauth_tool, mock_run_context):
+    """Test authentication with existing token"""
+    mock_run_context.get_oauth_token.return_value = 'existing_token'
+    
+    result = await oauth_tool.authenticate(mock_run_context)
+    
+    assert "Already authenticated" in result
+    mock_run_context.get_oauth_token.assert_called_once_with('test_tool')
+
+@pytest.mark.asyncio
+async def test_authenticate_with_auth_code(oauth_tool, mock_run_context):
+    """Test authentication with authorization code"""
+    mock_run_context.get_oauth_auth_code.return_value = 'test_auth_code'
+    
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {'access_token': 'new_token'}
+    
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    
+    with patch('os.getenv', side_effect=['test_client_id', 'test_client_secret']), \
+         patch('httpx.AsyncClient', return_value=mock_client):
+        result = await oauth_tool.authenticate(mock_run_context)
+        
+        assert "Successfully authenticated" in result
+        mock_run_context.set_oauth_token.assert_called_once_with('test_tool', 'new_token')
+
+@pytest.mark.asyncio
+async def test_authenticate_start_new_flow(oauth_tool, mock_run_context):
+    """Test starting new authentication flow"""
+    with patch('os.getenv', return_value='test_client_id'):
+        result = await oauth_tool.authenticate(mock_run_context)
+        
+        assert isinstance(result, OAuthFlowResult)
+        assert 'auth_url' in result.data
+        assert result.data['tool_name'] == 'test_tool'


### PR DESCRIPTION
- Implemented `OauthFlowRequest` event
- Implemented `get_oauth_callback_url` to get OAuth callback URL for a tool
- Also implemented `get_oauth_auth_code`  `set_oauth_auth_code` `set_oauth_token` `get_oauth_token` methods to enable to save and get auth_code and token
- Implemented `handle_oauth_callback` to save the returned `auth_code`. 
- `handle_oauth_static_callback` contains the callback URL that is called. We use `handle_oauth_static_callback` since OAuth providers often require registering a fixed callback URL that doesn't change between different authorization requests. 

The `auth_code` passed from the OAuth providers is saved from `handle_oauth_callback` method using  `set_oauth_auth_code`. Then, tools can get the saved `auth_code` using `get_oauth_auth_code`. 