### PR TITLE
Separate RAG dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "streamlit>=1.41.1",
     "swarm",
     "thespian>=4.0.0",
-    "litellm>=1.63.15",
+    "litellm>=1.63.14",
     "typer>=0.15.1",
     "cryptography>=44.0.0",
     "ray>=2.42.0",
@@ -22,17 +22,6 @@ dependencies = [
     "mkdocs-material>=9.6.4",
     "fastapi>=0.115.8",
     "setuptools>=75.8.0",
-    "weaviate-client>=4.10.4",
-    "chonkie[semantic]>=0.4.1",
-    "pypdf2>=3.0.1",
-    "transformers>=4.48.3",
-    "torch>=2.6.0",
-    "pypdf>=5.3.0",
-    "grpcio>=1.70.0",
-    "fastembed>=0.5.1",
-    "numpy>=2.1.3",
-    "extract-msg<=0.29.0",
-    "textract<1.6.4",
     "requests>=2.32.3",
     "python-magic>=0.4.27",
     "httpx>=0.28.1",
@@ -43,7 +32,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-
 # Dashboard package
 dashboard = []
 
@@ -66,8 +54,23 @@ github = [
     "gitpython>=3.1.44",
 ]
 
+# RAG packages
+rag = [
+    "weaviate-client>=4.10.4",
+    "chonkie[semantic]>=0.4.1",
+    "pypdf2>=3.0.1",
+    "transformers>=4.48.3",
+    "torch>=2.6.0",
+    "pypdf>=5.3.0",
+    "grpcio>=1.70.0",
+    "fastembed>=0.5.1",
+    "numpy>=2.1.3",
+    "extract-msg<=0.29.0",
+    "textract<1.6.4",
+]
+
 all = [
-    "agentic-framework[google-news,database,image-generator,github,dashboard]",
+    "agentic-framework[google-news,database,image-generator,github,dashboard,rag]",
 ]
 
 dev = [
@@ -79,7 +82,6 @@ dev = [
 
 [project.scripts]
 agentic = "agentic.cli:app"
-
 
 [tool.hatch.version]
 path = "agentic/__init__.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "agentic-framework"
 version = "0.1.3"
 description = "An opinionated framework for building sophisticated AI Agents"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.13"
 dependencies = [
     "html2text>=2024.2.26",
     "jinja2>=3.1.5",
@@ -29,6 +29,9 @@ dependencies = [
     "sse-starlette>=2.2.1",
     "sqlmodel>=0.0.22",
     "mcp[cli]>=1.5.0",
+    "numpy>=2.1.3",
+    "textract<1.6.4",
+    "pypdf2>=3.0.1",
 ]
 
 [project.optional-dependencies]
@@ -58,15 +61,11 @@ github = [
 rag = [
     "weaviate-client>=4.10.4",
     "chonkie[semantic]>=0.4.1",
-    "pypdf2>=3.0.1",
     "transformers>=4.48.3",
     "torch>=2.6.0",
-    "pypdf>=5.3.0",
     "grpcio>=1.70.0",
     "fastembed>=0.5.1",
-    "numpy>=2.1.3",
     "extract-msg<=0.29.0",
-    "textract<1.6.4",
 ]
 
 all = [


### PR DESCRIPTION
## Overview
Seperated RAG dependencies in `pyproject.toml`. Starting a process to decrease time to build GitHub Actions by refactoring unnecessary installs. 