### PR TITLE
added support for multiple users mapped to agent instances in the API

### DIFF
--- a/src/agentic/actor_agents.py
+++ b/src/agentic/actor_agents.py
@@ -1483,10 +1483,12 @@ class LocalAgentProxy(BaseAgentProxy):
         self.agent_config = {
             "name": self.name,
             "instructions": self.instructions,
+            "tools": self._tools.copy(),
             "model": self.model,
             "max_tokens": self.max_tokens,
             "memories": self.memories,
             "debug": self.debug,
+            "handle_turn_start": self._handle_turn_start,
             "result_model": self.result_model,
             # Functions will be added when creating instances
         }
@@ -1496,7 +1498,7 @@ class LocalAgentProxy(BaseAgentProxy):
     def _create_agent_instance(self, request_id: str|None=None):
         """Create a new local agent instance for a request"""
         agent = ActorBaseAgent(name=self.name)
-        
+
         # Set initial state
         agent.set_state(
             SetState(

--- a/src/agentic/runner.py
+++ b/src/agentic/runner.py
@@ -96,7 +96,7 @@ class RayAgentRunner:
         self.debug = DebugLevel(level)
         self.facade.set_debug_level(self.debug)
 
-    def repl_loop(self):
+    def repl_loop(self, default_context: dict = {}):
         hist = os.path.expanduser("~/.agentic_history")
         if os.path.exists(hist):
             readline.read_history_file(hist)
@@ -133,6 +133,7 @@ class RayAgentRunner:
 
                 request_id = self.facade.start_request(
                     line, 
+                    request_context=default_context,
                     debug=self.debug, 
                     continue_result=continue_result
                 ).request_id


### PR DESCRIPTION
This PR adds a hook to the API to look for a JWT token in the Auth header. If the token is present then we invoke a caller-supplied callback to resolve the "user" from the header. Then we map API calls to different Agent instances based on the user.

The lookup for the agent instance by user happens only on /process, which records the active agent by the request_id. Then in get_events we just find the right instance by the request ID. This seems logical, and has the side effect that if your brower client is using EventSource to stream get_events, it doesn't need to pass the JWT header in the event stream (which apparently isn't supported!).

I also added logging support to the API server which attempts to be mostly compatible with AGENTIC_DEBUG settings like we use with the cli.