### PR TITLE
Working run logs with subagents

### DIFF
--- a/examples/deep_research/oss_deep_research.py
+++ b/examples/deep_research/oss_deep_research.py
@@ -13,7 +13,7 @@ from agentic.tools import PlaywrightTool, TavilySearchTool
 # These can take any Litellm model path [see https://supercog-ai.github.io/agentic/Models/]
 # Or use aliases 'GPT_4O' or 'CLAUDE'
 PLANNER_MODEL = GPT_4O
-WRITER_MODEL = CLAUDE
+WRITER_MODEL = GPT_4O
 
 class Section(BaseModel):
     name: str = Field(

--- a/examples/deep_research/oss_deep_research.py
+++ b/examples/deep_research/oss_deep_research.py
@@ -38,11 +38,12 @@ class DeepResearchAgent(Agent):
     sections: Sections|None = None
     topic: str = ""
 
-    def __init__(self, name: str="OSS Deep Research", model: str=GPT_4O_MINI, playwright_fallback: bool = False, verbose: bool = False):
+    def __init__(self, name: str="OSS Deep Research", model: str=GPT_4O_MINI, playwright_fallback: bool = False, verbose: bool = False, **kwargs):
         super().__init__(
             name, 
             welcome="I am the OSS Deep Research agent. Please provide me with a topic to research.",
             model=model,
+            **kwargs
         )
         self.tavily_tool = TavilySearchTool(api_key=agentic_secrets.get_required_secret("TAVILY_API_KEY"))
 

--- a/examples/deep_research/oss_deep_research.py
+++ b/examples/deep_research/oss_deep_research.py
@@ -13,7 +13,7 @@ from agentic.tools import PlaywrightTool, TavilySearchTool
 # These can take any Litellm model path [see https://supercog-ai.github.io/agentic/Models/]
 # Or use aliases 'GPT_4O' or 'CLAUDE'
 PLANNER_MODEL = GPT_4O
-WRITER_MODEL = GPT_4O
+WRITER_MODEL = CLAUDE
 
 class Section(BaseModel):
     name: str = Field(

--- a/examples/march_madness.py
+++ b/examples/march_madness.py
@@ -215,11 +215,12 @@ TEAMS_LIST = TeamList(teams=[
 class MarchMadnessAgent(Agent):
     tournament: Tournament | None = None
     
-    def __init__(self, name: str="March Madness Predictor", model: str=ANALYZER_MODEL, verbose: bool = False):
+    def __init__(self, name: str="March Madness Predictor", model: str=ANALYZER_MODEL, verbose: bool = False, **kwargs):
         super().__init__(
             name, 
             welcome="I am the March Madness Prediction agent. I'll analyze matchups and build a complete tournament bracket prediction.",
             model=model,
+            **kwargs
         )
         self.tavily_tool = TavilySearchTool(api_key=agentic_secrets.get_required_secret("TAVILY_API_KEY"))
         self.verbose = verbose

--- a/src/agentic/actor_agents.py
+++ b/src/agentic/actor_agents.py
@@ -1260,8 +1260,6 @@ class BaseAgentProxy:
             resume_input = ResumeWithInput(
                 self.name,
                 continue_result,
-                self.name,
-                continue_result,
                 request_id=request_id
             )
             return self._get_resume_generator(agent_instance, resume_input)

--- a/src/agentic/actor_agents.py
+++ b/src/agentic/actor_agents.py
@@ -401,6 +401,7 @@ class ActorBaseAgent:
             yield event
 
     def _handlePromptOrResume(self, actor_message: Prompt | ResumeWithInput, request_id: str):
+        print("HANDLING PROMPT OR RESUME: ", request_id)
         if isinstance(actor_message, Prompt):
             self.run_context = (
                 RunContext(
@@ -617,6 +618,8 @@ class ActorBaseAgent:
                     message,
                     depth=depth,
                     debug=self.debug,
+                    request_context=self.run_context.context,
+                    request_id=str(uuid.uuid4())
                 )
             )
         
@@ -1171,6 +1174,7 @@ class BaseAgentProxy:
                      continue_result: dict = {}, run_id: Optional[str] = None,
                      debug: DebugLevel = DebugLevel(DebugLevel.OFF)) -> StartRequestResponse:
         """Start a new agent request"""
+        print(f"Starting request")
         self.debug.raise_level(debug)
 
         if not hasattr(depthLocal, 'depth'):
@@ -1200,7 +1204,7 @@ class BaseAgentProxy:
 
         def producer(queue, request_obj, continue_result):
             depthLocal.depth = request_obj.depth
-            for event in self.next_turn(request_obj, request_context=request_context, continue_result=continue_result, request_id=request_id):
+            for event in self._next_turn(request_obj, request_context=request_context, continue_result=continue_result, request_id=request_id):
                 queue.put(event)
             queue.put(self.queue_done_sentinel)
             # Cleanup the agent instance when done
@@ -1224,64 +1228,109 @@ class BaseAgentProxy:
             time.sleep(0.01)
         depthLocal.depth -= 1
 
-    def next_turn(self, request: str|Prompt, request_context: dict = {},
-                 request_id: str = None, continue_result: dict = {},
-                 debug: DebugLevel = DebugLevel(DebugLevel.OFF)) -> Generator[Event, Any, Any]:
-        """This is the key agent loop generator."""
+    def next_turn(self, request: str | Prompt, request_context: dict = {},
+              request_id: str = None, continue_result: dict = {},
+              debug: DebugLevel = DebugLevel(DebugLevel.OFF)) -> Generator[Event, Any, Any]:
+        """
+        Default agent orchestration logic. Subclasses may override this.
+        If not overridden, this handles prompt/resume and returns generator from agent.
+        """
+        # Get agent instance
+        agent_instance = self._get_agent_for_request(request_id)
+
+        # Prepare the prompt or resume input
+        if not continue_result:
+            prompt = (
+                request if isinstance(request, Prompt)
+                else Prompt(
+                    self.name,
+                    request,
+                    debug=debug,
+                    request_context=request_context,
+                    request_id=request_id,
+                )
+            )
+
+
+            # Transmit depth through the Prompt
+            if hasattr(depthLocal, 'depth') and depthLocal.depth > prompt.depth:
+                prompt.depth = depthLocal.depth
+
+            return self._get_prompt_generator(agent_instance, prompt)
+
+        else:
+            resume_input = ResumeWithInput(
+                self.name,
+                continue_result,
+                self.name,
+                continue_result,
+                request_id=request_id
+            )
+            return self._get_resume_generator(agent_instance, resume_input)
+
+
+    def _next_turn(self, request: str | Prompt, request_context: dict = {},
+               request_id: str = None, continue_result: dict = {},
+               debug: DebugLevel = DebugLevel(DebugLevel.OFF)) -> Generator[Event, Any, Any]:
+        """
+        Wraps `next_turn` to add run tracking and handle_event logging.
+        Always used internally by the proxy to ensure consistent behavior.
+        """
         self.cancelled = False
         self.debug.raise_level(debug)
-        
-        # Get or create request ID
+
         if not request_id:
             request_id = continue_result.get("request_id") or str(uuid.uuid4())
             if isinstance(request, Prompt):
                 request.request_id = request_id
 
-        # Handle mock settings - subclasses should implement this
         self._handle_mock_settings(self.mock_settings)
 
-        # Get the agent instance for this request
+        # Get agent instance for the run
         agent_instance = self._get_agent_for_request(request_id)
-        if not self.run_id and self.db_path:
-            self.init_run_tracking(agent_instance)
 
-        # Prepare the prompt or resume input
-        if not continue_result:
-            prompt = (
-                request if isinstance(request, Prompt) 
-                else Prompt(
-                    self.name, 
-                    request, 
-                    debug=self.debug, 
-                    request_context=request_context,
-                    request_id=request_id
-                )
-            )
-            # Transmit depth through the Prompt
-            if hasattr(depthLocal, 'depth') and depthLocal.depth > prompt.depth:
-                prompt.depth = depthLocal.depth
-                
-            # Get generator from agent
-            agent_gen = self._get_prompt_generator(agent_instance, prompt)
-        else:
-            # Handle resuming with input
-            resume_input = ResumeWithInput(
-                self.name, 
-                continue_result, 
-                request_id=request_id
-            )
-            agent_gen = self._get_resume_generator(agent_instance, resume_input)
-            
-        # Process events from generator
-        for event in self._process_generator(agent_gen):
+        # Initialize run tracking if needed
+        if (not self.run_id) and self.db_path:
+            self.init_run_tracking(agent_instance, run_id)
+
+        # Add run_id into context explicitly so child agents inherit it
+        request_context = {**request_context, "run_id": self.run_id}
+
+        # Call the user’s or default next_turn
+        event_gen = self.next_turn(
+            request=request,
+            request_context=request_context,
+            request_id=request_id,
+            continue_result=continue_result,
+            debug=debug
+        )
+
+        # Central logging of all events
+        for event in self._process_generator(event_gen):
             if self.cancelled:
                 raise TurnCancelledError()
-                
-            # Process results if needed
+
+            # Handle TurnEnd result validation
             if isinstance(event, TurnEnd):
                 event = self._process_turn_end(event)
+
+            print(f"Yielding event: {event.type}, run_id: {self.run_id}, agent: {self.name}")
             yield event
-            
+
+            # Only now: do logging after yielding
+            callback = self._agent.get_callback("handle_event") if hasattr(self, "_agent") else None
+            if callback:
+                context = RunContext(agent=self._agent, agent_name=self.name, run_id=self.run_id)
+                callback(event, context)
+
+
+
+    def handle_event_wrapper(self, event: Event):
+        callback = self._agent.get_callback("handle_event") if hasattr(self, "_agent") else None
+        if callback:
+            context = RunContext(agent=self._agent, agent_name=self.name, run_id=self.run_id)
+            callback(event, context)
+        
     def _get_prompt_generator(self, agent_instance, prompt):
         """Get generator for a new prompt - to be implemented by subclasses"""
         pass

--- a/src/agentic/actor_agents.py
+++ b/src/agentic/actor_agents.py
@@ -401,7 +401,6 @@ class ActorBaseAgent:
             yield event
 
     def _handlePromptOrResume(self, actor_message: Prompt | ResumeWithInput, request_id: str):
-        print("HANDLING PROMPT OR RESUME: ", request_id)
         if isinstance(actor_message, Prompt):
             self.run_context = (
                 RunContext(
@@ -1174,7 +1173,6 @@ class BaseAgentProxy:
                      continue_result: dict = {}, run_id: Optional[str] = None,
                      debug: DebugLevel = DebugLevel(DebugLevel.OFF)) -> StartRequestResponse:
         """Start a new agent request"""
-        print(f"Starting request")
         self.debug.raise_level(debug)
 
         if not hasattr(depthLocal, 'depth'):
@@ -1314,8 +1312,10 @@ class BaseAgentProxy:
             if isinstance(event, TurnEnd):
                 event = self._process_turn_end(event)
 
-            print(f"Yielding event: {event.type}, run_id: {self.run_id}, agent: {self.name}")
             yield event
+
+            if hasattr(event, "agent") and event.agent != self.name:
+                continue    
 
             # Only now: do logging after yielding
             callback = self._agent.get_callback("handle_event") if hasattr(self, "_agent") else None

--- a/src/agentic/api.py
+++ b/src/agentic/api.py
@@ -200,7 +200,6 @@ class AgentAPIServer:
         ):
             """Process a new request"""
             ctx = {"user": user} if user else {}
-            print("In process request, context is: ", ctx)
             req_event = agent.start_request(
                 request=request.prompt,
                 request_context=ctx,
@@ -208,7 +207,8 @@ class AgentAPIServer:
                 debug=DebugLevel(request.debug) if request.debug else self.debug
             )
             # abusing the "registry" to track the agent per request
-            self.agent_registry[req_event.request_id] = agent
+            # Commented out 4/21/25 because it breaks resume with input
+            # self.agent_registry[req_event.request_id] = agent
             return req_event
                 
         # Resume endpoint
@@ -240,12 +240,14 @@ class AgentAPIServer:
             request_id: str, 
             agent_name: str,
             stream: bool = False, 
+            agent = Depends(get_agent)
         ):
             """Get events for a request"""
-            if request_id in self.agent_registry:
-                agent = self.agent_registry[request_id]
-            else:
-                agent: Agent = get_agent(agent_name)
+            # Commented out 4/21/25 because it breaks resume with input
+            # if request_id in self.agent_registry:
+            #     agent = self.agent_registry[request_id]
+            # else:
+            #     agent: Agent = get_agent(agent_name)
 
             if not stream:
                 # Non-streaming response

--- a/src/agentic/dashboard/src/app/hooks/useChat.tsx
+++ b/src/agentic/dashboard/src/app/hooks/useChat.tsx
@@ -20,8 +20,6 @@ export function useChat(agentPath: string, agentName: string, currentRunId: stri
   const prevRunIdRef = useRef<string | undefined | null>(currentRunId);
   
   // Fetch run logs when runId changes
-  // If running Deep Researcher or other custom next_turn agents uncomment this line and comment out the next one
-  // const { data: runLogs, isLoading: isLoadingRunLogs } = useRunLogs(agentPath, null);
   const { data: runLogs, isLoading: isLoadingRunLogs } = useRunLogs(agentPath, currentRunId ?? null);
   
   // Reset events when currentRunId changes to undefined/null

--- a/src/agentic/run_manager.py
+++ b/src/agentic/run_manager.py
@@ -15,7 +15,6 @@ from agentic.common import RunContext
 from agentic.utils.json import make_json_serializable
 from agentic.db.db_manager import DatabaseManager
 from agentic.utils.directory_management import get_runtime_filepath
-import json
 
 class RunManager:
     """

--- a/src/agentic/run_manager.py
+++ b/src/agentic/run_manager.py
@@ -35,23 +35,26 @@ class RunManager:
         """Generic event handler that processes all events and logs them appropriately"""
         db_manager = DatabaseManager(db_path=self.db_path)
         # Initialize a new run when we see a Prompt event
-        self.current_run_id = run_context.run_id
-        if not self.current_run_id:
-            run_context.run_id = self.initial_run_id
-            self.current_run_id = self.initial_run_id
-        print(f"Handling event: {event.type}, run ID: {self.current_run_id}")
 
         if isinstance(event, PromptStarted) and not self.current_run_id:
-            print(f"Creating run with ID: {self.initial_run_id}")
+            if type(event.payload)==dict:
+                prompt = event.payload['content']
+            else:
+                prompt = str(event.payload)
             run = db_manager.create_run(
                 run_id=self.initial_run_id,
                 agent_id=run_context.agent_name,
                 user_id=self.user_id,
-                initial_prompt=json.dumps(make_json_serializable(event.payload)),
+                initial_prompt=prompt
             )
             self.current_run_id = run.id
             run_context.run_id = run.id 
             
+        self.current_run_id = run_context.run_id
+        if not self.current_run_id:
+            run_context.run_id = self.initial_run_id
+            self.current_run_id = self.initial_run_id
+        # print(f"Handling event: {event.type}, run ID: {self.current_run_id}")
         # Skip if we haven't initialized a run yet
         if not self.current_run_id:
             return

--- a/src/agentic/run_manager.py
+++ b/src/agentic/run_manager.py
@@ -53,7 +53,6 @@ class RunManager:
         if not self.current_run_id:
             run_context.run_id = self.initial_run_id
             self.current_run_id = self.initial_run_id
-        # print(f"Handling event: {event.type}, run ID: {self.current_run_id}")
         # Skip if we haven't initialized a run yet
         if not self.current_run_id:
             return


### PR DESCRIPTION
## Overview
closes #86 
The run logging was not created with subagents in mind, therefore the code needed refactoring for agents such as the deep researcher to log and work correctly. 
Changes made:
- Refactored the main callback logic to `_next_turn` to allow overrides to `next_turn` functions which can create subagents and yield events from them. 
- The handle_event function in run_manager needed refactoring to make sure it is using the correct run_id by replacing the `current_run_id` by run_context.run_id (the agent that is calling the event)
- Some minor checks were needed. For example, chcecking that the agent name is the same as the agent calling the event to avoid duplicate logging and the event payload was being written as a dictionary so that is a temporary fix to correctly find the content text.