### PR TITLE
Fix DuckDuckGo and RestApi tools, make sure tests catch failures

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,3 +8,8 @@ include src/agentic/dashboard/types.d.ts
 include src/agentic/dashboard/README.md
 include src/agentic/dashboard/components.json
 include src/agentic/dashboard/package.json
+
+recursive-include examples *.py *.md *.yaml *.db
+recursive-include src/agentic/tools *.py
+
+recursive-exclude * __pycache__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,11 @@ playwright = [
     "playwright>=1.51.0",
 ]
 
+podcast = [
+    "openai>=1.75.0",
+    "beautifulsoup4>=4.13.4",
+]
+
 text-to-speech = [
     "pydub>=0.25.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,6 @@ packages = [
     "agentic", 
     "agentic.custom_models",
     "agentic.tools",
-    "agentic.tools.utils",
     "agentic.swarm",
     "agentic.streamlit",
     "agentic.dashboard",

--- a/src/agentic/tools/duckduckgo.py
+++ b/src/agentic/tools/duckduckgo.py
@@ -31,32 +31,26 @@ class DuckDuckGoTool(BaseAgenticTool):
 
     Free and does not require any setup.
     """
-
-    region: Optional[str] = "wt-wt"
-    """
-    See https://pypi.org/project/duckduckgo-search/#regions
-    """
-    safesearch: str = "moderate"
-    """
-    Options: strict, moderate, off
-    """
-    time: Optional[str] = "y"
-    """
-    Options: d, w, m, y
-    """
-    max_results: int = 5
-    backend: str = "auto"
-    """
-    Options: auto, html, lite
-    """
-    source: str = "text"
-    """
-    Options: text, news, images
-    """
-
     model_config = ConfigDict(
         extra="forbid",
     )
+
+    def __init__(
+        self,
+        region: Optional[str] = "wt-wt", # Options: see https://pypi.org/project/duckduckgo-search/#regions
+        safesearch: str = "moderate", # Options: strict, moderate, off
+        time: Optional[str] = "y", # Options: d, w, m, y
+        max_results: int = 5,
+        backend: str = "auto", # Options: auto, html, lite
+        source: str = "text", # Options: text, news, images
+    ):
+        self.region = region
+        self.safesearch = safesearch
+        self.time = time
+        self.max_results = max_results
+        self.backend = backend
+        self.source = source
+        super().__init__()
 
     def get_tools(self):
         return [self.web_search_with_duckduckgo]

--- a/src/agentic/tools/example_tool.py
+++ b/src/agentic/tools/example_tool.py
@@ -2,7 +2,6 @@ from typing import Callable, Dict, Optional, Union
 import pandas as pd
 
 from agentic.tools.base import BaseAgenticTool
-<<<<<<< HEAD
 from agentic.tools.utils.registry import tool_registry, ConfigRequirement
 from agentic.common import RunContext, PauseForInputResult
 
@@ -19,22 +18,7 @@ from agentic.common import RunContext, PauseForInputResult
         ),
     ],
 )
-=======
-from agentic.tools.utils.registry import tool_registry
-from agentic.common import RunContext, PauseForInputResult
 
-###
-## Register the tool to the tool registry
-###
-
-@tool_registry.register(
-    name="ExampleTool",
-    description="Example tool for demponstrating tool registration",
-    dependencies=[],
-    config_requirements=[],
-)
-
->>>>>>> 7b27f0e (Register all tools)
 class ExampleTool(BaseAgenticTool):
     """
     A tool that demonstrates the standard patterns for implementing agentic tools.

--- a/src/agentic/tools/example_tool.py
+++ b/src/agentic/tools/example_tool.py
@@ -2,6 +2,7 @@ from typing import Callable, Dict, Optional, Union
 import pandas as pd
 
 from agentic.tools.base import BaseAgenticTool
+<<<<<<< HEAD
 from agentic.tools.utils.registry import tool_registry, ConfigRequirement
 from agentic.common import RunContext, PauseForInputResult
 
@@ -18,6 +19,22 @@ from agentic.common import RunContext, PauseForInputResult
         ),
     ],
 )
+=======
+from agentic.tools.utils.registry import tool_registry
+from agentic.common import RunContext, PauseForInputResult
+
+###
+## Register the tool to the tool registry
+###
+
+@tool_registry.register(
+    name="ExampleTool",
+    description="Example tool for demponstrating tool registration",
+    dependencies=[],
+    config_requirements=[],
+)
+
+>>>>>>> 7b27f0e (Register all tools)
 class ExampleTool(BaseAgenticTool):
     """
     A tool that demonstrates the standard patterns for implementing agentic tools.

--- a/src/agentic/tools/podcast_tool.py
+++ b/src/agentic/tools/podcast_tool.py
@@ -1,11 +1,35 @@
 from typing import Callable
-
-from agentic.tools.text_to_speech_tool import TextToSpeechTool
-from .base import BaseAgenticTool
-
 import requests
 from bs4 import BeautifulSoup
 import openai
+
+from agentic.tools.text_to_speech_tool import TextToSpeechTool
+from agentic.tools.base import BaseAgenticTool
+from agentic.tools.utils.registry import tool_registry, ConfigRequirement, Dependency
+
+@tool_registry.register(
+    name="PodcastTool",
+    description="Tool for downloading and summarizing articles and converting them to podcasts",
+    dependencies=[
+        Dependency(
+            name="beautifulsoup4",
+            version="4.13.4",
+            type="pip",
+        ),
+        Dependency(
+            name="openai",
+            version="1.75.0",
+            type="pip",
+        ),
+    ],
+    config_requirements=[
+        ConfigRequirement(
+            key="OPENAI_API_KEY",
+            description="OpenAI API key",
+            required=True,
+        )
+    ],
+)
 
 class PodcastTool(BaseAgenticTool):
     def __init__(self):

--- a/src/agentic/tools/rest_api_tool.py
+++ b/src/agentic/tools/rest_api_tool.py
@@ -12,7 +12,7 @@ import httpx
 from urllib.parse import urlparse, parse_qsl, urlencode
 
 from agentic.tools.base import BaseAgenticTool
-from agentic.tools.utils.registry import tool_registry, Dependency
+from agentic.tools.utils.registry import tool_registry
 from agentic.common import RunContext
 
 class AsyncRequestBuilder:
@@ -114,9 +114,16 @@ class AsyncRequestBuilder:
     config_requirements=[],
 )
 class RestApiTool(BaseAgenticTool):
-    request_map: dict[str, AsyncRequestBuilder] = {}
-    return_dataframe: bool = False
-    run_context: RunContext | None = None
+    def __init__(
+        self,
+        request_map:  dict[str, AsyncRequestBuilder] = {},
+        return_dataframe: bool = False,
+        run_context: Optional[RunContext] = None
+    ):
+        super().__init__()
+        self.request_map = request_map
+        self.return_dataframe = return_dataframe
+        self.run_context = run_context
 
     def get_tools(self) -> list[Callable]:
         return [

--- a/tests/utils/tools_utils.py
+++ b/tests/utils/tools_utils.py
@@ -1,5 +1,6 @@
 import inspect
 import importlib
+import os
 from pathlib import Path
 from typing import Any
 
@@ -45,3 +46,22 @@ def get_tool_classes_from_module(module_name: str) -> dict[str, type[Any]]:
             tool_classes[name] = obj
 
     return tool_classes
+
+def get_base_tool_class():
+    """
+    Get the BaseAgenticTool class from the base module.
+    """
+    try:
+        base_module = importlib.import_module('agentic.tools.base')
+        return getattr(base_module, 'BaseAgenticTool')
+    except (ImportError, AttributeError) as e:
+        raise ImportError("Could not import BaseAgenticTool: " + str(e))
+
+def get_tool_files_in_directory(directory: Path | str, exclude_files: list[Path | str] = ['__init__.py']) -> list[Path]:
+    """
+    Get a list of all Python files in the given directory excluding the specified files.
+    """
+    return [
+        f for f in os.listdir(directory) 
+        if f.endswith('.py') and f not in exclude_files
+    ]


### PR DESCRIPTION
## Changes:
- Fix duckduckgo tool imports
- Add init function to rest api tool
- Make sure init and get_tools functions are overridden by all tools
- Exclude pycache from package imports