### PR TITLE
refactor: dynamic tools agent example

### DIFF
--- a/examples/dynamic_tools_agent.py
+++ b/examples/dynamic_tools_agent.py
@@ -1,6 +1,5 @@
 from agentic.tools import (
     AutomaticTools,
-    BrowserUseTool,
     DatabaseTool,
     DuckDuckGoTool,
     GoogleNewsTool,

--- a/examples/dynamic_tools_agent.py
+++ b/examples/dynamic_tools_agent.py
@@ -12,6 +12,7 @@ from agentic.tools import (
 
 from agentic.common import Agent, AgentRunner
 from agentic.tools.utils.registry import tool_registry
+from agentic.models import GPT_4O_MINI
 
 # This is a demonstration of dynamic tool use. You can add a tool to an agent at any time. This
 # demo uses a meta tool called "AutomaticTools" which will automatically load tools from the
@@ -27,7 +28,7 @@ agent = Agent(
     name="Dynamic Tools Agent",
     welcome="I have a list of tools which I can enable and use on-demand. Query the list of tools to start.",
     instructions="You are a helpful assistant. You can list tools or enable a tool for different purposes.",
-    model="openai/gpt-4o-mini",
+    model=GPT_4O_MINI,
     tools=[
         AutomaticTools(
             tool_classes=[


### PR DESCRIPTION
This PR makes two improvements to the dynamic tools agent example to work:

1. Replaces the hardcoded string literal "openai/gpt-4o-mini" with the imported GPT_4O_MINI constant from agentic.models, improving maintainability and consistency
2. Removes the unused BrowserUseTool import to keep imports clean