### PR TITLE
fix: used get_context instead of attribute error value of context

### DIFF
--- a/src/agentic/actor_agents.py
+++ b/src/agentic/actor_agents.py
@@ -611,7 +611,7 @@ class ActorBaseAgent:
                     message,
                     depth=depth,
                     debug=self.debug,
-                    request_context=self.run_context.context,
+                    request_context=self.run_context.get_context(),
                     request_id=str(uuid.uuid4())
                 )
             )


### PR DESCRIPTION
- fix attribute error in `call_child` method. We were calling a `context` attribute that does not exist in `RunContext` object but rather `_context` exist