### PR TITLE
fix agent_oracle close connection error

### DIFF
--- a/src/agentic/utils/rag_helper.py
+++ b/src/agentic/utils/rag_helper.py
@@ -159,10 +159,12 @@ def rag_index_file(
     """Index a file using configurable Weaviate Embedded and chunking parameters"""
 
     console = Console()
+    client_created = False
     try:
         with Status("[bold green]Initializing Weaviate..."):
             if client is None:
                 client = init_weaviate()
+                client_created = True
             create_collection(client, index_name, distance_metric)
             
         with Status("[bold green]Initializing models..."):
@@ -229,7 +231,7 @@ def rag_index_file(
                 
         console.print(f"[bold green]✅ Indexed {len(chunks)} chunks in {index_name}")
     finally:
-        if client:
+        if client and client_created:
             client.close()
     return "indexed"
         


### PR DESCRIPTION
When I run `python examples/agentic_oracle.py`, I get a closed `weaviateclient` after processing the first file.
`weaviate.exceptions.WeaviateClosedClientError: The `WeaviateClient` is closed. Run `client.connect()` to (re)connect!`

Right now, I added a `client_created` flag to track whether we created the client within the function and close if only `client` is created within the `rag_index_file` function so that we don't have a closed connection when we are processing more than one files from RAGTool `__init__` method. With this pr, `agentic_oracle.py` runs successfully