### PR TITLE
Added Subagent Logging

### DIFF
--- a/examples/deep_research/oss_deep_research.py
+++ b/examples/deep_research/oss_deep_research.py
@@ -149,7 +149,8 @@ class DeepResearchAgent(Agent):
                 "Generate search queries that will help with planning the sections of the report.",
                 request_context={
                     "topic": self.topic, 
-                    "num_queries": self.num_queries
+                    "num_queries": self.num_queries,
+                    "run_id": request_context.get("run_id")
                 }
             )
 
@@ -168,6 +169,7 @@ class DeepResearchAgent(Agent):
                     "web_context": content, 
                     "topic": self.topic,
                     "feedback": feedback,
+                    "run_id": request_context.get("run_id")
                 }
             )
 
@@ -208,7 +210,8 @@ provide feedback to regenerate the report plan:\n
                     "section_title": section.name,
                     "section_topic": section.description, 
                     "report_context": draft_report,
-                    "section_content": section.content
+                    "section_content": section.content,
+                    "run_id": request_context.get("run_id")
                 },
             )
             finals.append(report_section)
@@ -216,7 +219,8 @@ provide feedback to regenerate the report plan:\n
         sources = yield from self.final_reference_writer.final_result(
             "Generate a list of important sources referenced from the full report content.",
             {
-                "report_context": draft_report
+                "report_context": draft_report,
+                "run_id": request_context.get("run_id")
             }
         )
 
@@ -242,7 +246,8 @@ provide feedback to regenerate the report plan:\n
             "Generate search queries on the provided topic.",
             request_context={
                 "section_topic": section.description, 
-                "num_queries": self.num_queries
+                "num_queries": self.num_queries,
+                "run_id": report_context.run_id if isinstance(report_context, RunContext) else None
             },
         )
         msg = f"Research queries for section {index+1} - {section.name}:\n" + "\n".join([q.search_query for q in queries.queries]) + "\n\n"
@@ -260,7 +265,8 @@ provide feedback to regenerate the report plan:\n
                 "section_title": section.name,
                 "section_topic": section.description,
                 "section_content": section.content,
-                "web_context": web_context
+                "web_context": web_context,
+                "run_id": report_context.run_id if isinstance(report_context, RunContext) else None
             }
         )
 

--- a/src/agentic/actor_agents.py
+++ b/src/agentic/actor_agents.py
@@ -407,6 +407,8 @@ class ActorBaseAgent:
                 if self.run_context is None
                 else self.run_context.update(actor_message.request_context)
             )
+            if not self.run_context.run_id and "run_id" in actor_message.request_context:
+                self.run_context.run_id = actor_message.request_context["run_id"]  
 
             # Middleware to modify the input prompt (or change agent context)
             if self._callbacks.get('handle_turn_start'):
@@ -1177,6 +1179,9 @@ class BaseAgentProxy:
         if isinstance(request, str):
             request = self._check_for_prompt_match(request)
 
+        if not run_id and "run_id" in request_context:
+            run_id = request_context["run_id"]
+
         # Create request ID if not provided in continue_result
         request_id = continue_result.get("request_id") or str(uuid.uuid4())
 
@@ -1275,6 +1280,9 @@ class BaseAgentProxy:
                 request.request_id = request_id
 
         self._handle_mock_settings(self.mock_settings)
+
+        if not self.run_id and "run_id" in request_context:
+            self.run_id = request_context["run_id"]
 
         # Get agent instance for the run
         agent_instance = self._get_agent_for_request(request_id)


### PR DESCRIPTION
## Overview
This PR introduces corrections to the subagent logging to ensure subagent logs correctly appear in the event logs on the dashboard. The problem was that subagents were creating their own `run_id` and therefore were not being linked to the run and the parent agent. 