### PR TITLE
Fixed TeamList length access in March Madness agent

### DIFF
--- a/examples/march_madness.py
+++ b/examples/march_madness.py
@@ -297,7 +297,7 @@ class MarchMadnessAgent(Agent):
         self.region_seeds = self.get_region_seeds(teams_list.teams)
 
         if self.verbose:
-            yield ChatOutput(self.name, {"content": f"Retrieved {len(teams_list)} teams for the {tournament_year} NCAA Tournament"})
+            yield ChatOutput(self.name, {"content": f"Retrieved {len(teams_list.teams)} teams for the {tournament_year} NCAA Tournament"})
         
         # 2. Research each team in depth
         for team in teams_list.teams:


### PR DESCRIPTION
Fixed TypeError when accessing TeamList length by correctly accessing the teams attribute.

Changes:
- Modified `len(teams_list)` to `len(teams_list.teams)` to properly count the number of teams
- This fixes the AttributeError that occurred when trying to get the length of the TeamList object directly

The error occurred because TeamList is a Pydantic model containing a list of teams in its 'teams' attribute, and we need to access that attribute to get the actual count of teams.