### PR TITLE
Add AutomaticTools docs and remove unused `universal_read_file` method

### DIFF
--- a/docs/tools/tool-library/automatic-tools.md
+++ b/docs/tools/tool-library/automatic-tools.md
@@ -14,13 +14,10 @@ The `AutomaticTools` is a meta-tool that provides dynamic tool discovery and man
 ### get_tool_listing
 
 ```python
-async def get_tool_listing(show_connections_only: Optional[bool] = False) -> list[dict]
+async def get_tool_listing() -> list[dict]
 ```
 
 Returns a list of all available tools with their names and descriptions.
-
-**Parameters:**
-- `show_connections_only (bool, optional)`: Whether to show only connection-related tools
 
 **Returns:**
 A list of dictionaries containing tool names and descriptions.
@@ -92,13 +89,11 @@ The AutomaticTools uses several key features:
 3. **Keyword Matching**: Falls back to keyword matching when semantic search doesn't find matches
 4. **Dynamic Loading**: Can load both tool classes and individual tool functions
 
-## Helper Methods
+## Helper Method
 
-The tool includes several helper methods:
+The tool includes a helper method:
 
 - `get_docstring`: Extracts documentation from tools
-- `get_tools`: Returns the list of available tool methods
-- Various internal methods for tool management and file handling
 
 ## Notes
 

--- a/docs/tools/tool-library/automatic-tools.md
+++ b/docs/tools/tool-library/automatic-tools.md
@@ -1,0 +1,109 @@
+# AutomaticTools
+
+The `AutomaticTools` is a meta-tool that provides dynamic tool discovery and management capabilities. It allows agents to automatically detect, search for, and enable appropriate tools based on user needs.
+
+## Features
+
+- Automatically discover available tools from a configured list
+- Search for tools based on purpose or functionality
+- Dynamically enable tools for the agent
+- Support for both tool classes and tool functions
+
+## Methods
+
+### get_tool_listing
+
+```python
+async def get_tool_listing(show_connections_only: Optional[bool] = False) -> list[dict]
+```
+
+Returns a list of all available tools with their names and descriptions.
+
+**Parameters:**
+- `show_connections_only (bool, optional)`: Whether to show only connection-related tools
+
+**Returns:**
+A list of dictionaries containing tool names and descriptions.
+
+### search_for_tool
+
+```python
+async def search_for_tool(purpose: str) -> list[str]
+```
+
+Searches for one or more tools related to the indicated purpose using both semantic search and keyword matching.
+
+**Parameters:**
+- `purpose (str)`: The intended purpose or functionality needed
+
+**Returns:**
+A list of tool names that match the purpose.
+
+### enable_agent_tool
+
+```python
+async def enable_agent_tool(tool_name: str, run_context: RunContext) -> str
+```
+
+Enables a specific tool for the agent to use.
+
+**Parameters:**
+- `tool_name (str)`: The name of the tool to enable
+- `run_context (RunContext)`: The agent's running context
+
+**Returns:**
+A status message indicating whether the tool was successfully enabled or suggestions for similar tools.
+
+## Example Usage
+
+```python
+from agentic.common import Agent
+from agentic.tools import AutomaticTools, WeatherTool, GoogleNewsTool, DatabaseTool
+
+# Create an agent with dynamic tool capabilities
+dynamic_agent = Agent(
+    name="Dynamic Assistant",
+    instructions="You are a helpful assistant that can dynamically enable tools as needed.",
+    tools=[
+        AutomaticTools(
+            tool_classes=[
+                WeatherTool,
+                GoogleNewsTool,
+                DatabaseTool
+            ]
+        )
+    ]
+)
+
+# The agent can now dynamically enable tools based on user needs
+response = dynamic_agent << "What's the weather like in New York?"
+# The agent will automatically enable the WeatherTool and use it
+
+response = dynamic_agent << "Show me the latest tech news"
+# The agent will automatically enable the GoogleNewsTool and use it
+```
+
+## Implementation Details
+
+The AutomaticTools uses several key features:
+
+1. **Tool Registry**: Integrates with Agentic's tool registry system for tool discovery
+2. **Semantic Search**: Uses LLM-based semantic search to find relevant tools
+3. **Keyword Matching**: Falls back to keyword matching when semantic search doesn't find matches
+4. **Dynamic Loading**: Can load both tool classes and individual tool functions
+
+## Helper Methods
+
+The tool includes several helper methods:
+
+- `get_docstring`: Extracts documentation from tools
+- `get_tools`: Returns the list of available tool methods
+- Various internal methods for tool management and file handling
+
+## Notes
+
+- The tool automatically handles tool discovery and loading
+- It provides intelligent suggestions when requested tools aren't found
+- Supports both class-based tools and function-based tools
+- Integrates with Agentic's tool registry system
+- Can be used to create highly dynamic agents that adapt their capabilities based on user needs 

--- a/src/agentic/tools/automatic_tools.py
+++ b/src/agentic/tools/automatic_tools.py
@@ -38,16 +38,15 @@ class AutomaticTools(BaseAgenticTool):
             self.enable_agent_tool,
         ]
 
-    async def get_tool_listing(
-        self, show_connections_only: Optional[bool] = False
-    ) -> list[dict]:
-        """ " Returns the list of all available tools."""
+    async def get_tool_listing(self) -> list[dict]:
+        """Returns the list of all available tools."""
 
         records = []
         for tool_class in self.tool_classes:
             records.append(
                 {"name": tool_class.__name__, "description": get_docstring(tool_class)}
             )
+                
         for tool_function in self.tool_functions:
             records.append(
                 {

--- a/src/agentic/tools/automatic_tools.py
+++ b/src/agentic/tools/automatic_tools.py
@@ -1,14 +1,12 @@
 from typing import Callable, Any, Optional, Type
 import re
 from pydantic import BaseModel
-import pandas as pd
 
 from agentic.llm import llm_generate_with_format
 from agentic.common import RunContext
 from agentic.tools.base  import BaseAgenticTool
 from agentic.tools.utils.registry import tool_registry
 from agentic.tools.file_download import FileDownloadTool
-from agentic.tools.rag_tool import RAGTool
 
 def get_docstring(obj: Any) -> str:
     return obj.__doc__ or ""
@@ -38,7 +36,6 @@ class AutomaticTools(BaseAgenticTool):
             self.get_tool_listing,
             self.search_for_tool,
             self.enable_agent_tool,
-            self.universal_read_file,
         ]
 
     async def get_tool_listing(
@@ -120,16 +117,3 @@ Return no results if no tool fits the purpose.
         # In case the agent requested a tool that doesn't exist, see if we can suggest one
         suggestions = await self.search_for_tool(tool_name)
         return f"Error: Tool not found: {tool_name}. Perhaps you want one of: {', '.join(suggestions)}"
-
-    async def universal_read_file(self, file_name: str) -> Any:
-        """Reads the contents for any file type. Also supports reading from URLs."""
-        try:
-            value, mime_type = await RAGTool._universal_read_file(
-                file_name, self.run_context
-            )
-            if isinstance(value, str):
-                return value
-            elif isinstance(value, pd.DataFrame):
-                return self.get_dataframe_preview(value)
-        except ValueError as e:
-            return f"Error reading file: {e}"


### PR DESCRIPTION
- Adds comprehensive documentation for `AutomaticTools` in `docs/tools/tool-library/`
- Removes unused `universal_read_file` method from `AutomaticTools` since:
   - It was trying to call a non-existent `RAGTool._universal_read_file` method
   - It wasn't being used anywhere in the codebase
- Removes unused `show_connections_only` parameter from `get_tool_listing` method