### PR TITLE
Fix for issue with Windows dashboard setup not detecting npm 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@
 Agentic makes it easy to create AI agents - autonomous software programs that understand natural language
 and can use tools to do work on your behalf.
 
-Agentic is in the tradition of _opinionated frameworks_. We've tried to encode lots of sensisible
+Agentic is in the tradition of _opinionated frameworks_. We've tried to encode lots of sensible
 defaults and best practices into the design, testing and deployment of agents. 
 
 Agentic is a few different things:
 
 - A lightweight agent framework. Same part of the stack as SmolAgents or PydanticAI.
-- A referenece implementation of the [agent protocol](https://github.com/supercog-ai/agent-protocol).
+- A reference implementation of the [agent protocol](https://github.com/supercog-ai/agent-protocol).
 - An agent runtime built on [Ray](https://github.com/ray-project/ray)
 - An optional "batteries included" set of features to help you get running quickly:
   * Built in FastAPI API for your agent
@@ -80,7 +80,7 @@ uv pip install -e "./agentic[all,dev]"
 uv pip install -e "./agentic[all,dev]" --extra-index-url https://download.pytorch.org/whl/cpu
 ```
 
-these commands will install the `agentic` package locally so that you can use the `agentic` cli command
+these commands will install the `agentic` package locally so that you can use the `agentic` CLI command
 and so your pythonpath is set correctly.
 
 ### Install the package

--- a/src/agentic/dashboard/setup.py
+++ b/src/agentic/dashboard/setup.py
@@ -63,8 +63,10 @@ def install_dependencies():
     
     logger.info("Installing dashboard dependencies...")
     try:
+        # Only add the .cmd extension if on Windows, otherwise use regular command
+        cmd = 'npm.cmd' if os.name == 'nt' else 'npm'
         subprocess.run(
-            ["npm", "install"], 
+            [cmd, "install"], 
             cwd=DASHBOARD_ROOT, 
             check=True
         )
@@ -85,8 +87,10 @@ def build_dashboard():
     
     logger.info("Building dashboard...")
     try:
+        # Only add the .cmd extension if on Windows, otherwise use regular command
+        cmd = 'npm.cmd' if os.name == 'nt' else 'npm'
         subprocess.run(
-            ["npm", "run", "build"], 
+            [cmd, "run", "build"], 
             cwd=DASHBOARD_ROOT, 
             check=True
         )
@@ -111,7 +115,9 @@ def run_built_dashboard(port: Optional[int] = None):
         logger.error("Node.js or npm not found. Required to run the dashboard.")
         return None
     
-    command = ["npm", "run", "start"]
+    # Only add the .cmd extension if on Windows, otherwise use regular command
+    cmd = 'npm.cmd' if os.name == 'nt' else 'npm'
+    command = [cmd, "run", "start"]
     
     if port:
         command.extend(["--", "-p", str(port)])
@@ -136,7 +142,10 @@ def start_dashboard(port: Optional[int] = None, dev_mode: bool = False):
     Returns:
         subprocess.Popen: The process running the dashboard, or None if startup failed.
     """
-    command = ["npm", "run"]
+
+    # Only add the .cmd extension if on Windows, otherwise use regular command
+    cmd = 'npm.cmd' if os.name == 'nt' else 'npm'
+    command = [cmd, "run"]
     if dev_mode:
         if not install_dependencies():
             return None

--- a/src/agentic/dashboard/setup.py
+++ b/src/agentic/dashboard/setup.py
@@ -4,7 +4,7 @@ Dashboard management module.
 This module provides functions for setting up, running, and managing
 the Next.js dashboard.
 """
-
+import os
 import subprocess
 import sys
 import time
@@ -25,13 +25,17 @@ def check_npm_dependencies():
         bool: True if Node.js and npm are installed, False otherwise.
     """
     try:
+
         node_version = subprocess.run(
             ["node", "--version"], 
             capture_output=True, 
             text=True
         ).stdout.strip()
+
+        # Only add the .cmd extension if on Windows, otherwise use regular command
+        cmd = 'npm.cmd' if os.name == 'nt' else 'npm'
         npm_version = subprocess.run(
-            ["npm", "--version"], 
+            [cmd, "--version"], 
             capture_output=True, 
             text=True
         ).stdout.strip()


### PR DESCRIPTION
### Issue
Issue with npm not being detected on Windows when attempted to setup the Supercog dashboard, even when they are properly installed and PATH is configured. Returns error "npm or node not detected".

### Change
in src/agentic/dashboard/setup.py, imported os library, then changed the subprocess command of "npm" to "npm.cmd" if the os.name is "nt" (windows) instead of "posix" (unix/linux/mac)

The reason this bug exists is because on Windows, command-line executables installed via npm (like npm, npx, etc.) are typically provided as .cmd files (e.g., npm.cmd) in the system PATH:

Windows does not natively recognize scripts without an extension as executable.
The .cmd extension tells the Windows shell to run the file as a command script.
On Unix-like systems (Linux/macOS), the executable is just npm (no extension).