### PR TITLE
Fix for dependency conflicts causing installation issues on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,8 @@ git clone git@github.com:supercog-ai/agentic.git
 uv venv  --python 3.12
 source .venv/bin/activate
 
-# For MacOS
+# For MacOS, Linux, or Windows
 uv pip install -e "./agentic[all,dev]"
-
-# For Linux or Windows
-uv pip install -e "./agentic[all,dev]" --extra-index-url https://download.pytorch.org/whl/cpu
 ```
 
 these commands will install the `agentic` package locally so that you can use the `agentic` CLI command

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,11 @@ dependencies = [
     "click==8.1.8"
 ]
 
+[[tool.uv.index]]
+name = "torch"
+url = "https://download.pytorch.org/whl/cpu"
+default = false
+
 [project.optional-dependencies]
 
 # Streamlit package
@@ -42,7 +47,7 @@ rag = [
     "chonkie[semantic]==1.0.6",
     "transformers==4.51.3",
     'torch==2.6.0; platform_system == "Darwin"',
-    'torch==2.6.0+cpu; platform_system == "Linux" or platform_system == "Windows"',
+    'torch==2.6.0; platform_system == "Linux" or platform_system == "Windows"',
     "grpcio==1.71.0",
     "fastembed==0.6.1",
     "extract-msg==0.29.0",


### PR DESCRIPTION
### Issue
Dependency conflicts when trying to install the agentic framework on Windows with 
"uv pip install -e "./agentic[all,dev]" --extra-index-url https://download.pytorch.org/whl/cpu"
![image](https://github.com/user-attachments/assets/bfd9a9fe-dd4a-4791-a6fa-543f82af9ff9)

### Cause
By default, uv will only consider package versions that are published on the first index it finds for a given package name. When using the flag "--extra-index-url" it makes that extra index the default index to look for packages, causing weird issues. For example, that jinja2 cannot be found on version 3.1.6 when it does exist on PyPI. This is because it is looking for that package solely on the download website for torch, which has outdated links.

### Fix
Remove "--extra-index-url" from the installation instructions on the README.md and instead add a few lines to the pyproject.toml config file that lets uv search for another index without setting it to default, since setting it to default excludes PyPI. Also remove the +cpu option for Windows users, since it does not exist.
![image](https://github.com/user-attachments/assets/0b20ea94-513e-48a1-a6e8-6c0d9240da6e)

uv can now install agentic with no issues on Windows.

![image](https://github.com/user-attachments/assets/896b334a-6f6e-494f-88fc-8c8ee457dd83)

