### PR TITLE
Fix double content bug in thread logging

### DIFF
--- a/src/agentic/actor_agents.py
+++ b/src/agentic/actor_agents.py
@@ -1243,12 +1243,10 @@ class BaseAgentProxy:
         if thread_id == 'NEW':
             history = []
         else:
-            print("LOADING THREAD LOGS FOR ID: ", thread_id)
             history = validate_chat_history(
                 reconstruct_chat_history_from_thread_logs(self.get_thread_logs(thread_id))
             )
         update = {"history": history}
-        pprint(update)
         self._update_state(update)
 
     def _create_agent_instance(self, request_id: str):

--- a/src/agentic/thread_manager.py
+++ b/src/agentic/thread_manager.py
@@ -78,7 +78,11 @@ class ThreadManager:
         role = event.payload.role if isinstance(event.payload, Message) else "system"
         event_name = event.type
         payload = event.payload.content if isinstance(event.payload, Message) else event.payload
-        event_data = {"content": payload} if payload else {}
+        event_data =  {}
+        if payload and isinstance(payload, dict) and "content" in payload:
+            event_data = payload
+        else:
+            event_data = { "content": payload }
         
         if isinstance(event, Output):
             event_data = payload
@@ -161,6 +165,9 @@ def reconstruct_chat_history_from_thread_logs(thread_logs: List[ThreadLog]) -> L
             content = ""
             if isinstance(event_data, dict):
                 content = event_data.get("content", "")
+                # Necessary to support db logs that were created with a buggy duel content structure ({content: {content: "prompt"}})
+                if isinstance(content, dict):
+                    content = content.get("content", "")
             elif isinstance(event_data, str):
                 content = event_data
             


### PR DESCRIPTION
`PromptStarted` events were getting logged like this: `{"content": {"content": "actual prompt"}} which was surfaced with Scott's recent changes to loading chat history into the state. This addresses that and also allows for logs to be viewed even if the bug affects them.