### PR TITLE
Geolocation Tool and Example Agent

### DIFF
--- a/examples/geolocation_agent.py
+++ b/examples/geolocation_agent.py
@@ -1,0 +1,23 @@
+from agentic.tools import GeolocationTool
+
+from agentic.common import Agent, AgentRunner
+from agentic.models import GPT_4O_MINI, LMSTUDIO_QWEN
+# This is the "hello world" agent example. A simple agent with a tool for getting weather reports.
+
+MODEL=GPT_4O_MINI # try locally with LMSTUDIO_QWEN
+
+agent = Agent(
+    name="Geolocation Agent",
+    welcome="I am a simple agent here to help answer your geolocation questions.",
+    instructions="You are a helpful assistant that reports the weather.",
+    model=MODEL,
+    tools=[GeolocationTool()],
+    prompts = {
+        "location": "What is the location of the user?",
+        "time": "What is the time in the user's location?",
+        "timezone": "What is the timezone of the user?",
+    }
+)
+
+if __name__ == "__main__":
+    AgentRunner(agent).repl_loop()

--- a/examples/geolocation_agent.py
+++ b/examples/geolocation_agent.py
@@ -1,10 +1,10 @@
+# A simple agent to demonstrate the Geolocation tool.
+
 from agentic.tools import GeolocationTool
-
 from agentic.common import Agent, AgentRunner
-from agentic.models import GPT_4O_MINI, LMSTUDIO_QWEN
-# This is the "hello world" agent example. A simple agent with a tool for getting weather reports.
+from agentic.models import GPT_4O_MINI
 
-MODEL=GPT_4O_MINI # try locally with LMSTUDIO_QWEN
+MODEL=GPT_4O_MINI
 
 agent = Agent(
     name="Geolocation Agent",
@@ -16,6 +16,9 @@ agent = Agent(
         "location": "What is the location of the user?",
         "time": "What is the time in the user's location?",
         "timezone": "What is the timezone of the user?",
+        "isp": "What is my ISP?",
+        "ip": "What is my IP address?",
+        "gps": "What are my gps coordinates in (latitude, longitude) format?"
     }
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,8 @@ dev = [
     "black==25.1.0",
     "mkdocs-material==9.6.12",
     "mkdocs-swagger-ui-tag==0.7.1",
-    "mike==2.1.3"
+    "mike==2.1.3",
+    "pytest-mock"
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,10 @@ duckduckgo = [
     "duckduckgo-search==8.0.1",
 ]
 
+geolocation = [
+    "tzlocal==5.3.1",
+]
+
 github = [
     "gitpython==3.1.44",
 ]
@@ -109,7 +113,7 @@ text-to-speech = [
 ]
 
 all-tools = [
-    "agentic-framework[airbnb,browser-use,database,duckduckgo,github,google-news,image-generator,imap,mcp,meeting-baas,playwright,text-to-speech]",
+    "agentic-framework[airbnb,browser-use,database,duckduckgo,geolocation,github,google-news,image-generator,imap,mcp,meeting-baas,playwright,text-to-speech]",
 ]
 
 all = [

--- a/src/agentic/tools/__init__.py
+++ b/src/agentic/tools/__init__.py
@@ -32,6 +32,7 @@ _TOOL_MAPPING = {
     "TextToSpeechTool": "text_to_speech_tool",
     "UnitTestingTool": "unit_test_tool",
     "WeatherTool": "weather_tool",
+    "GeolocationTool": "geolocation_tool",
 }
 
 __all__ = [
@@ -64,6 +65,7 @@ __all__ = [
     "TextToSpeechTool",
     "UnitTestingTool",
     "WeatherTool",
+    "GeolocationTool"
 ]
 
 # Tool cache to avoid repeated imports

--- a/src/agentic/tools/__init__.pyi
+++ b/src/agentic/tools/__init__.pyi
@@ -8,6 +8,7 @@ from .database_tool import DatabaseTool
 from .duckduckgo import DuckDuckGoTool
 from .example_tool import ExampleTool
 from .file_download import FileDownloadTool
+from .geolocation_tool import GeolocationTool
 from .github_tool import GithubTool
 from .google_news import GoogleNewsTool
 from .human_interrupt import HumanInterruptTool
@@ -40,6 +41,7 @@ __all__ = [
     "ExampleTool",
     "FileDownloadTool",
     "GithubTool",
+    "GeolocationTool",
     "GoogleNewsTool",
     "HumanInterruptTool",
     "ImageGeneratorTool",

--- a/src/agentic/tools/geolocation_tool.py
+++ b/src/agentic/tools/geolocation_tool.py
@@ -1,0 +1,125 @@
+from typing import Callable, Dict, Optional, Tuple
+
+import datetime
+
+import tzlocal
+
+
+#import requests
+#from ip2geotools.databases.noncommercial import DbIpCity
+
+from agentic.tools.base import BaseAgenticTool
+from agentic.tools.utils.registry import tool_registry, ConfigRequirement
+from agentic.common import ThreadContext
+
+@tool_registry.register(
+    name="GeolocationTool",
+    description="Tool to get the current geographical location of the user",
+    #dependencies=["ip2geotools"],
+    config_requirements=[
+        ConfigRequirement(
+            key="free",
+            description="API key for IP geolocation service (if using a paid service)",
+            required=False,
+        ),
+    ],
+)
+class GeolocationTool(BaseAgenticTool):
+    """
+    A tool that retrieves the current geographical location of the user
+    based on their public IP address.
+    """
+    
+    def __init__(self, api_key: Optional[str] = None):
+        """
+        Initialize the Geolocation tool.
+        
+        Args:
+            api_key: Optional API key for IP geolocation services
+        """
+        self.api_key = api_key
+
+    def get_tools(self) -> list[Callable]:
+        return [
+            #self.get_current_location,
+            self.get_current_time,
+            self.get_current_timezone,
+        ]
+
+    
+    async def get_current_location(self) -> Dict[str, str]:
+        """
+        Get the current geographical location based on the user's public IP address.
+        
+        Returns:
+            Dictionary containing location information including:
+            - ip: The public IP address
+            - city: The city name
+            - region: The region/state
+            - country: The country name
+            - latitude: The latitude coordinate
+            - longitude: The longitude coordinate
+            - timezone: The timezone
+        """
+        return "place"
+        '''
+        try:
+            # First, get the public IP address
+            ip_response = requests.get('https://api.ipify.org?format=json')
+            ip_response.raise_for_status()
+            ip_address = ip_response.json()['ip']
+            
+            # Get location information using the IP address
+            response = DbIpCity.get(ip_address, api_key=self.api_key)
+            
+            return {
+                'ip': ip_address,
+                'city': response.city,
+                'region': response.region,
+                'country': response.country,
+                'latitude': response.latitude,
+                'longitude': response.longitude,
+                'timezone': response.time_zone
+            }
+            
+        except Exception as e:
+            raise Exception(f"Failed to retrieve location information: {str(e)}")
+        '''
+
+    async def get_current_time(self, timezone: Optional[str] = None) -> Dict[str, str]:
+        
+        try:
+            current_time = datetime.datetime.now()    
+            return current_time.isoformat(),
+
+        except Exception as e:
+            raise Exception(f"Failed to get current time: {str(e)}")
+
+    async def get_current_timezone(self) -> Dict[str, str]:
+        """
+        Get the current timezone information based on the user's location.
+        
+        Returns:
+            Dictionary containing:
+            - timezone: The timezone name (e.g., 'America/Los_Angeles')
+            - offset: UTC offset in hours
+        """
+        try:
+            '''
+            location = self.get_current_location()
+            timezone = location.get('timezone', 'UTC')
+            tz = pytz.timezone(timezone)
+            now = datetime.datetime.now(tz)
+            offset = now.utcoffset(local_tz).total_seconds() / 3600  # Convert to hours
+            return {
+                'timezone': local_tz,
+                'offset': offset
+            }
+            '''
+
+            # Get the local timezone
+            local_tz = tzlocal.get_localzone()
+            return local_tz
+
+        except Exception as e:
+            raise Exception(f"Failed to get timezone information: {str(e)}")

--- a/src/agentic/tools/geolocation_tool.py
+++ b/src/agentic/tools/geolocation_tool.py
@@ -35,16 +35,16 @@ class GeolocationTool(BaseAgenticTool):
         ]
 
 
-    async def get_time(self) -> Dict[str, str]:
+    async def get_time(self) -> str:
         """ Returns the current time of the client. """ 
         try:
             current_time = datetime.datetime.now()    
-            return current_time.isoformat(),
+            return current_time.isoformat()
 
         except Exception as e:
             raise Exception(f"Failed to get current time: {str(e)}")
 
-    async def get_timezone(self) -> Dict[str, str]:
+    async def get_timezone(self) -> str:
         """
         Get the current timezone information based on the user's location.
         
@@ -60,7 +60,7 @@ class GeolocationTool(BaseAgenticTool):
         except Exception as e:
             raise Exception(f"Failed to get timezone information: {str(e)}")
 
-    async def get_ip_and_location(self) -> Dict[str, str]:
+    async def get_ip_and_location(self) -> str:
         """
         Get the current geographical location based on the user's public IP address.
         
@@ -106,9 +106,7 @@ class GeolocationTool(BaseAgenticTool):
             Service Provider: {service_provider}
             """
 
-        except requests.exceptions.RequestException as e:
-            print(f"An error occurred with the network request: {e}")
-        except KeyError:
-            print("Could not parse the expected data from the API response.")
         except Exception as e:
-            print(f"An unexpected error occurred: {e}")
+            error_msg = f"An error occurred while getting location: {str(e)}"
+            print(error_msg)
+            return error_msg

--- a/src/agentic/tools/geolocation_tool.py
+++ b/src/agentic/tools/geolocation_tool.py
@@ -1,93 +1,42 @@
-from typing import Callable, Dict, Optional, Tuple
-
+from typing import Callable, Dict, Optional
 import datetime
 
 import tzlocal
-
-
-#import requests
-#from ip2geotools.databases.noncommercial import DbIpCity
+import requests
 
 from agentic.tools.base import BaseAgenticTool
-from agentic.tools.utils.registry import tool_registry, ConfigRequirement
-from agentic.common import ThreadContext
+from agentic.tools.utils.registry import tool_registry
 
 @tool_registry.register(
     name="GeolocationTool",
     description="Tool to get the current geographical location of the user",
-    #dependencies=["ip2geotools"],
-    config_requirements=[
-        ConfigRequirement(
-            key="free",
-            description="API key for IP geolocation service (if using a paid service)",
-            required=False,
-        ),
-    ],
+    config_requirements=[],
 )
 class GeolocationTool(BaseAgenticTool):
     """
     A tool that retrieves the current geographical location of the user
-    based on their public IP address.
+    based on their public IP address.  NOTE: the tool only has access to 
+    geolocation information for the machine it is running on, so this tool
+    is useful when part of the client application (CLI) and less so when
+    part of a cloud server solution.
     """
     
-    def __init__(self, api_key: Optional[str] = None):
+    def __init__(self):
         """
         Initialize the Geolocation tool.
-        
-        Args:
-            api_key: Optional API key for IP geolocation services
         """
-        self.api_key = api_key
+        pass
 
     def get_tools(self) -> list[Callable]:
         return [
-            #self.get_current_location,
-            self.get_current_time,
-            self.get_current_timezone,
+            self.get_time,
+            self.get_timezone,
+            self.get_ip_and_location,
         ]
 
-    
-    async def get_current_location(self) -> Dict[str, str]:
-        """
-        Get the current geographical location based on the user's public IP address.
-        
-        Returns:
-            Dictionary containing location information including:
-            - ip: The public IP address
-            - city: The city name
-            - region: The region/state
-            - country: The country name
-            - latitude: The latitude coordinate
-            - longitude: The longitude coordinate
-            - timezone: The timezone
-        """
-        return "place"
-        '''
-        try:
-            # First, get the public IP address
-            ip_response = requests.get('https://api.ipify.org?format=json')
-            ip_response.raise_for_status()
-            ip_address = ip_response.json()['ip']
-            
-            # Get location information using the IP address
-            response = DbIpCity.get(ip_address, api_key=self.api_key)
-            
-            return {
-                'ip': ip_address,
-                'city': response.city,
-                'region': response.region,
-                'country': response.country,
-                'latitude': response.latitude,
-                'longitude': response.longitude,
-                'timezone': response.time_zone
-            }
-            
-        except Exception as e:
-            raise Exception(f"Failed to retrieve location information: {str(e)}")
-        '''
 
-    async def get_current_time(self, timezone: Optional[str] = None) -> Dict[str, str]:
-        
+    async def get_time(self) -> Dict[str, str]:
+        """ Returns the current time of the client. """ 
         try:
             current_time = datetime.datetime.now()    
             return current_time.isoformat(),
@@ -95,31 +44,71 @@ class GeolocationTool(BaseAgenticTool):
         except Exception as e:
             raise Exception(f"Failed to get current time: {str(e)}")
 
-    async def get_current_timezone(self) -> Dict[str, str]:
+    async def get_timezone(self) -> Dict[str, str]:
         """
         Get the current timezone information based on the user's location.
         
         Returns:
-            Dictionary containing:
-            - timezone: The timezone name (e.g., 'America/Los_Angeles')
-            - offset: UTC offset in hours
+            Timezone string in "Region/City" IANA tz database format.
+            https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
         """
         try:
-            '''
-            location = self.get_current_location()
-            timezone = location.get('timezone', 'UTC')
-            tz = pytz.timezone(timezone)
-            now = datetime.datetime.now(tz)
-            offset = now.utcoffset(local_tz).total_seconds() / 3600  # Convert to hours
-            return {
-                'timezone': local_tz,
-                'offset': offset
-            }
-            '''
-
             # Get the local timezone
             local_tz = tzlocal.get_localzone()
             return local_tz
 
         except Exception as e:
             raise Exception(f"Failed to get timezone information: {str(e)}")
+
+    async def get_ip_and_location(self) -> Dict[str, str]:
+        """
+        Get the current geographical location based on the user's public IP address.
+        
+        Returns:
+            Geolocation data as a string in the following format:
+                City: {city}
+                Region: {region}
+                Country: {country}
+                Coordinates (Lat, Lon): {loc}
+                Timezone: {timezone}
+                IP: {public_ip}
+                ISP: {org}
+        """
+        try:
+            # Step 1: Get the public IP address
+            # We use ipify.org, a simple and reliable service for this.
+            ip_response = requests.get('https://api.ipify.org?format=json')
+            ip_response.raise_for_status()  # Raise an exception for bad status codes
+            ip_data = ip_response.json()
+            public_ip = ip_data['ip']
+            
+            # Step 2: Get the location based on the IP address
+            # We use ipinfo.io, which provides a free geolocation API.
+            location_response = requests.get(f'https://ipinfo.io/{public_ip}/json')
+            location_response.raise_for_status()
+            location_data = location_response.json()
+
+            # Print the location data in a readable format
+            city = location_data.get('city', 'N/A')
+            region = location_data.get('region', 'N/A')
+            country = location_data.get('country', 'N/A')
+            loc = location_data.get('loc', 'N/A') # Latitude,Longitude
+            service_provider = location_data.get('org', 'N/A') # ISP (Internet Service Provider)
+            timezone = location_data.get('timezone', 'N/A')
+
+            return f"""
+            City: {city}
+            Region: {region}
+            Country: {country}
+            Coordinates (Lat, Lon): {loc}
+            Timezone: {timezone}
+            IP: {public_ip}
+            Service Provider: {service_provider}
+            """
+
+        except requests.exceptions.RequestException as e:
+            print(f"An error occurred with the network request: {e}")
+        except KeyError:
+            print("Could not parse the expected data from the API response.")
+        except Exception as e:
+            print(f"An unexpected error occurred: {e}")

--- a/tests/test_geolocation_tool.py
+++ b/tests/test_geolocation_tool.py
@@ -36,7 +36,86 @@ async def test_get_timezone(geolocation_tool, mocker):
 
 
 @pytest.mark.asyncio
-async def test_get_ip_and_location_success(geolocation_tool, mocker):
+async def test_get_ip_success(geolocation_tool, mocker):
+    # Mock the requests
+    mock_requests = mocker.patch('agentic.tools.geolocation_tool.requests')
+    
+    # Mock the ipify response
+    ip_response = MagicMock()
+    ip_response.json.return_value = {'ip': '123.45.67.89'}
+    ip_response.raise_for_status.return_value = None
+    mock_requests.get.return_value = ip_response
+    
+    # Call the method
+    result = await geolocation_tool.get_ip()
+    
+    # Verify the result contains the IP address
+    assert '123.45.67.89' in result
+    
+    # Verify the request was made correctly
+    mock_requests.get.assert_called_once()
+    assert 'ipify.org' in mock_requests.get.call_args[0][0]
+
+@pytest.mark.asyncio
+async def test_get_ip_request_error(geolocation_tool, mocker):
+    # Mock the requests module and its exceptions
+    mock_requests = mocker.patch('agentic.tools.geolocation_tool.requests')
+    
+    # Create a mock exception class that inherits from Exception
+    class MockRequestException(Exception):
+        pass
+    
+    # Set up the mock to raise our custom exception
+    mock_requests.exceptions.RequestException = MockRequestException
+    mock_requests.get.side_effect = MockRequestException("Network error")
+    
+    # Call the method and expect an exception to be caught and printed
+    with patch('builtins.print') as mock_print:
+        result = await geolocation_tool.get_ip()
+        
+        # Verify that an error message was printed
+        mock_print.assert_called()
+        assert "An error occurred while getting ip: Network error" in str(mock_print.call_args[0][0])
+
+@pytest.mark.asyncio
+async def test_get_location_success(geolocation_tool, mocker):
+    # Mock the requests
+    mock_requests = mocker.patch('agentic.tools.geolocation_tool.requests')
+    
+    # Mock the ipinfo response
+    location_response = MagicMock()
+    location_response.json.return_value = {
+        'ip': '123.45.67.89',
+        'city': 'Test City',
+        'region': 'Test Region',
+        'country': 'US',
+        'loc': '40.7128,-74.0060',
+        'org': 'Test ISP',
+        'timezone': 'America/New_York'
+    }
+    location_response.raise_for_status.return_value = None
+    mock_requests.get.return_value = location_response
+    
+    # Call the method with a test IP
+    test_ip = '123.45.67.89'
+    result = await geolocation_tool.get_location(test_ip)
+    
+    # Verify the result contains expected information
+    assert 'Test City' in result
+    assert 'Test Region' in result
+    assert 'US' in result
+    assert '40.7128,-74.0060' in result
+    assert 'Test ISP' in result
+    assert 'America/New_York' in result
+    assert test_ip in result
+    
+    # Verify the request was made correctly
+    mock_requests.get.assert_called_once()
+    assert test_ip in mock_requests.get.call_args[0][0]
+    assert 'ipinfo.io' in mock_requests.get.call_args[0][0]
+
+@pytest.mark.asyncio
+async def test_get_location_without_ip(geolocation_tool, mocker):
     # Mock the requests
     mock_requests = mocker.patch('agentic.tools.geolocation_tool.requests')
     
@@ -61,50 +140,25 @@ async def test_get_ip_and_location_success(geolocation_tool, mocker):
     # Set up the mock to return different responses for different URLs
     mock_requests.get.side_effect = [ip_response, location_response]
     
-    # Call the method
-    result = await geolocation_tool.get_ip_and_location()
+    # Call the method without an IP
+    result = await geolocation_tool.get_location()
     
     # Verify the result contains expected information
     assert 'Test City' in result
-    assert 'Test Region' in result
-    assert 'US' in result
-    assert '40.7128,-74.0060' in result
-    assert 'Test ISP' in result
-    assert 'America/New_York' in result
+    assert '123.45.67.89' in result
     
-    # Verify the requests were made correctly
+    # Verify both requests were made
     assert mock_requests.get.call_count == 2
     assert 'ipify.org' in mock_requests.get.call_args_list[0][0][0]
     assert 'ipinfo.io' in mock_requests.get.call_args_list[1][0][0]
-
-@pytest.mark.asyncio
-async def test_get_ip_and_location_request_error(geolocation_tool, mocker):
-    # Mock the requests module and its exceptions
-    mock_requests = mocker.patch('agentic.tools.geolocation_tool.requests')
-    
-    # Create a mock exception class that inherits from Exception
-    class MockRequestException(Exception):
-        pass
-    
-    # Set up the mock to raise our custom exception
-    mock_requests.exceptions.RequestException = MockRequestException
-    mock_requests.get.side_effect = MockRequestException("Network error")
-    
-    # Call the method and expect an exception to be caught and printed
-    with patch('builtins.print') as mock_print:
-        result = await geolocation_tool.get_ip_and_location()
-        
-        # Verify that an error message was printed
-        mock_print.assert_called()
-        assert "An error occurred while getting location: Network error" in str(mock_print.call_args[0][0])
-
 
 @pytest.mark.asyncio
 async def test_get_tools(geolocation_tool):
     # Test that get_tools returns the expected list of callable methods
     tools = geolocation_tool.get_tools()
     
-    assert len(tools) == 3
+    assert len(tools) == 4
     assert geolocation_tool.get_time in tools
     assert geolocation_tool.get_timezone in tools
-    assert geolocation_tool.get_ip_and_location in tools
+    assert geolocation_tool.get_ip in tools
+    assert geolocation_tool.get_location in tools

--- a/tests/test_geolocation_tool.py
+++ b/tests/test_geolocation_tool.py
@@ -1,0 +1,110 @@
+import pytest
+import asyncio
+from unittest.mock import patch, MagicMock, AsyncMock
+from datetime import datetime
+
+from agentic.tools.geolocation_tool import GeolocationTool
+
+@pytest.fixture
+def geolocation_tool():
+    return GeolocationTool()
+
+@pytest.mark.asyncio
+async def test_get_time(geolocation_tool):
+    # Test that get_time returns a valid ISO format datetime string
+    result = await geolocation_tool.get_time()
+    
+    # Should be a string
+    assert isinstance(result, str)
+    
+    # Should be a valid ISO format datetime
+    try:
+        datetime.fromisoformat(result)
+    except ValueError:
+        pytest.fail("Returned time is not in ISO format")
+
+@pytest.mark.asyncio
+async def test_get_timezone(geolocation_tool, mocker):
+    # Mock tzlocal to return a known timezone
+    mock_tz = mocker.patch('agentic.tools.geolocation_tool.tzlocal')
+    mock_tz.get_localzone.return_value = 'America/New_York'
+    
+    result = await geolocation_tool.get_timezone()
+    
+    assert result == 'America/New_York'
+    mock_tz.get_localzone.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_ip_and_location_success(geolocation_tool, mocker):
+    # Mock the requests
+    mock_requests = mocker.patch('agentic.tools.geolocation_tool.requests')
+    
+    # Mock the ipify response
+    ip_response = MagicMock()
+    ip_response.json.return_value = {'ip': '123.45.67.89'}
+    ip_response.raise_for_status.return_value = None
+    
+    # Mock the ipinfo response
+    location_response = MagicMock()
+    location_response.json.return_value = {
+        'ip': '123.45.67.89',
+        'city': 'Test City',
+        'region': 'Test Region',
+        'country': 'US',
+        'loc': '40.7128,-74.0060',
+        'org': 'Test ISP',
+        'timezone': 'America/New_York'
+    }
+    location_response.raise_for_status.return_value = None
+    
+    # Set up the mock to return different responses for different URLs
+    mock_requests.get.side_effect = [ip_response, location_response]
+    
+    # Call the method
+    result = await geolocation_tool.get_ip_and_location()
+    
+    # Verify the result contains expected information
+    assert 'Test City' in result
+    assert 'Test Region' in result
+    assert 'US' in result
+    assert '40.7128,-74.0060' in result
+    assert 'Test ISP' in result
+    assert 'America/New_York' in result
+    
+    # Verify the requests were made correctly
+    assert mock_requests.get.call_count == 2
+    assert 'ipify.org' in mock_requests.get.call_args_list[0][0][0]
+    assert 'ipinfo.io' in mock_requests.get.call_args_list[1][0][0]
+
+@pytest.mark.asyncio
+async def test_get_ip_and_location_request_error(geolocation_tool, mocker):
+    # Mock the requests module and its exceptions
+    mock_requests = mocker.patch('agentic.tools.geolocation_tool.requests')
+    
+    # Create a mock exception class that inherits from Exception
+    class MockRequestException(Exception):
+        pass
+    
+    # Set up the mock to raise our custom exception
+    mock_requests.exceptions.RequestException = MockRequestException
+    mock_requests.get.side_effect = MockRequestException("Network error")
+    
+    # Call the method and expect an exception to be caught and printed
+    with patch('builtins.print') as mock_print:
+        result = await geolocation_tool.get_ip_and_location()
+        
+        # Verify that an error message was printed
+        mock_print.assert_called()
+        assert "An error occurred while getting location: Network error" in str(mock_print.call_args[0][0])
+
+
+@pytest.mark.asyncio
+async def test_get_tools(geolocation_tool):
+    # Test that get_tools returns the expected list of callable methods
+    tools = geolocation_tool.get_tools()
+    
+    assert len(tools) == 3
+    assert geolocation_tool.get_time in tools
+    assert geolocation_tool.get_timezone in tools
+    assert geolocation_tool.get_ip_and_location in tools


### PR DESCRIPTION
Adds a geolocation tool with the following capabilities:

- Time: uses python's datetime library to get current time on the local machine.
- Timezone: uses python's tzlocal library to get the timezone of the local machine.
- Location: uses requests library to get ip of local machine, ip is then used in another request, which returns the following information:
    1. city
    2. region
    3. country
    4. coordinates (longitude/latitude) --> not the exact location of user, but the isp location.
    5. timezone
    6.  public ip
    7. service provider

Note: gets geolocation information based on public ip of the machine it is being run on, meaning inaccuracies can occur if agent is being run by a server or if ip points to a different location (such as if a vpn is being used).
 
Other addition:   
Very basic agent also created to test the tool, added to agentic's example agents.