### PR TITLE
Multiple RAG features

### DIFF
--- a/docs/tools/tool-library/rag-tool.md
+++ b/docs/tools/tool-library/rag-tool.md
@@ -20,6 +20,7 @@ def __init__(default_index: str = "knowledge_base", index_paths: list[str] = [])
 
 - `default_index (str)`: Name of the default vector store index (default: "knowledge_base")
 - `index_paths (list[str])`: List of files or glob patterns to index during initialization
+- `recursive (bool)`: Enables recursive glob patterns (/**/) (default: False)
 
 ## Methods
 
@@ -111,6 +112,13 @@ print(response)
 pre_indexed_rag = RAGTool(
     default_index="documentation",
     index_paths=["./docs/*.md"]
+)
+
+# Create a RAG tool with a pre-indexed directory
+pre_indexed_rag = RAGTool(
+    default_index="codebase",
+    index_paths=["../**/*.py","../**/*.md"],
+    recursive=True
 )
 
 # Create an agent with pre-indexed documentation

--- a/src/agentic/utils/file_reader.py
+++ b/src/agentic/utils/file_reader.py
@@ -57,6 +57,9 @@ def read_file(file_path: str, mime_type: str|None = None) -> tuple[str, str]:
                 return text, mime_type
         elif mime_type == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
             return pd.read_excel(file_path).to_csv(), mime_type
+        elif mime_type == "text/x-python":
+            with open(file_path,"r") as f:
+                return f.read(), mime_type
         else:
             return textract.process(file_path).decode('utf-8'), mime_type
     except Exception as e:


### PR DESCRIPTION
### Features
- Added documentation for recursive glob patterns:   docs/tools/tool-library/rag-tool.md
- Added support for indexing several files on initiation, and recursive glob patterns:   src/agentic/tools/rag_tool.py
- Added support for .py files:   src/agentic/utils/file_reader.py
- Added rag_index_multiple_files:   src/agentic/utils/rag_helper.py

### Notes
- Recursive glob patterns require the `recursive = True` parameter to be passed into intialization of `rag_tool` (default: `False`)
- Glob patterns use `rag_index_multiple_files` as they return a list
- HTTP file paths use `rag_index_file`